### PR TITLE
Send Embed support

### DIFF
--- a/discordia/containers/snowflakes/channels/TextChannel.lua
+++ b/discordia/containers/snowflakes/channels/TextChannel.lua
@@ -73,7 +73,7 @@ local function getPinnedMessages(self)
 	return _messageIterator(self, client._api:getPinnedMessages(self._id))
 end
 
-local function sendMessage(self, content, mentions, tts)
+local function sendMessage(self, content, embed, mentions, tts)
 	if type(mentions) == 'table' then
 		local strings = {}
 		if mentions.getMentionString then
@@ -96,7 +96,7 @@ local function sendMessage(self, content, mentions, tts)
 	end
 	local client = self._parent._parent or self._parent
 	local success, data = client._api:createMessage(self._id, {
-		content = content, tts = tts
+		content = content, tts = tts, embed = embed
 	})
 	if success then return self._messages:new(data) end
 end


### PR DESCRIPTION
Approving this file change proposal you will:
1- let us send embed messages
2- once you update Discordia some users, including me, will not have to update this file again to be able to send embeds as we already are doing.

I'm sure you'll find a better way to add embed message but this is a workaround until that moment. Almost every lib is supporting sending embeds.