### PR TITLE
Small change in API Header

### DIFF
--- a/discordia/client/API.lua
+++ b/discordia/client/API.lua
@@ -62,10 +62,12 @@ function API:setToken(token)
 	self._headers['Authorization'] = token
 end
 
-function API:request(method, route, endpoint, payload)
+function API:request(method, route, endpoint, payload, ContentType)
 
 	local url = "https://discordapp.com/api" .. endpoint
-
+	
+	self._headers['Content-Type'] = ContentType or self._headers['Content-Type']
+	
 	local reqHeaders = {}
 	for k, v in pairs(self._headers) do
 		insert(reqHeaders, {k, v})

--- a/discordia/client/API.lua
+++ b/discordia/client/API.lua
@@ -66,7 +66,7 @@ function API:request(method, route, endpoint, payload, contentType)
 
 	local url = "https://discordapp.com/api" .. endpoint
 	
-	self._headers['Content-Type'] = ContentType or self._headers['Content-Type']
+	self._headers['Content-Type'] = contentType or self._headers['Content-Type']
 	
 	local reqHeaders = {}
 	for k, v in pairs(self._headers) do

--- a/discordia/client/API.lua
+++ b/discordia/client/API.lua
@@ -62,7 +62,7 @@ function API:setToken(token)
 	self._headers['Authorization'] = token
 end
 
-function API:request(method, route, endpoint, payload, ContentType)
+function API:request(method, route, endpoint, payload, contentType)
 
 	local url = "https://discordapp.com/api" .. endpoint
 	


### PR DESCRIPTION
Added the possibility to swap from Content-Type depending on the function. 

It's not required to add the last arg but for sending files you do need to change Content-Type header to multipart/form-data.