### PR TITLE
Fix member.color returning false color

### DIFF
--- a/discordia/containers/snowflakes/Member.lua
+++ b/discordia/containers/snowflakes/Member.lua
@@ -101,7 +101,9 @@ end
 local function getColor(self)
 	local roles = {}
 	for role in self.roles do
-		insert(roles, role)
+		if role.color.value ~= 0 then
+			insert(roles, role)
+		end
 	end
 	sort(roles, sorter)
 	return roles[1] and roles[1].color or Color()


### PR DESCRIPTION
member.color returns a false value if the highest role on a member has no color, but a lower role on them has a color.