### PR TITLE
Fixed unicode emojis (which have null IDs) crashing Discordia

### DIFF
--- a/libs/containers/Reaction.lua
+++ b/libs/containers/Reaction.lua
@@ -10,7 +10,13 @@ local Reaction, get = require('class')('Reaction', Container)
 
 function Reaction:__init(data, parent)
 	Container.__init(self, data, parent)
-	self._emoji_id = data.emoji.id
+
+	-- The JSON decoder treats `null` as an empty table. If we have an empty table here it
+	-- is due to `null` being the emoji ID (therefor is a unicode emoji). Don't set the emojiID
+	if not( type( data.emoji.id ) == "table" and #data.emoji.id == 0 ) then
+		self._emoji_id = type( data.emoji.id ) == "table" and #data.emoji.id == 0
+	end
+
 	self._emoji_name = data.emoji.name
 end
 


### PR DESCRIPTION
## Problem
When calling `reaction:delete()` Discordia would crash. This is because `Resolver.emoji` is trying to concat a string and table.

```lua
function Resolver.emoji(obj)
	if isInstance(obj, classes.Emoji) then
                -- ...
	elseif isInstance(obj, classes.Reaction) then
		if obj.emojiId then
			return obj.emojiName .. ':' .. obj.emojiId -- This is the line that's crashing
		else
			return obj.emojiName
		end
	end
        -- ...
end
```

### Reason
This problem caused by two things:
- Discord provides no ID for Unicode emojis via it's gateway
- During payload decoding the JSON decoder makes `null` into an empty Lua table.

To fix we simply have to make `obj.emojiID` nil (or false) so that Resolver will just return the emojiName.

## First fix
When instantiating a Reaction object it is checked that the `data.event.id` field is a table (if it is, and has a length of zero). If it is a table `self._emoji_id` is simply not set (remains `nil`).

This fixes the bug because `Resolver.emoji` (the crashing function) will no longer see the emoji id (and try and concatenate with a string) and will instead just return the emojiName.

## Second fix
Another fix is to change `payload = decode(payload, 1, null)` to `payload = decode(payload, 1, nill)` on line 154 of `./libs/client/Shard.lua`

This fix may have unintended side effects, it was not tested a whole lot and it is to be assumed that the use of `json.null` is intentional (which is why I'm not PRing that fix).