### PR TITLE
Add support for object.self and object.itself.

### DIFF
--- a/libs/class.lua
+++ b/libs/class.lua
@@ -89,7 +89,8 @@ return setmetatable({
 	end
 
 	local bases = {...}
-	local getters = {}
+	local getters = {self = function(self) return self end}
+	getters.itself = getters.self
 	local setters = {}
 
 	for _, base in ipairs(bases) do


### PR DESCRIPTION
Adds support for `object.self` for Discordia class objects.

```lua
 --example usage
local T = SomeClass()
assert(T.self == T and T.itself == T)
```