### PR TITLE
Fast speed at voice stream start

### DIFF
--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -189,7 +189,7 @@ function VoiceConnection:_play(stream, duration)
 	local frame_size = SAMPLE_RATE * FRAME_DURATION / MS_PER_S
 	local pcm_len = frame_size * CHANNELS
 
-	local first = true
+	local init = true
 
 	while elapsed < duration do
 
@@ -214,7 +214,7 @@ function VoiceConnection:_play(stream, duration)
 		local packet = header .. ffi_string(encrypted, encrypted_len)
 		udp:send(packet, ip, port)
 
-		if first then
+		if init then
 			start = hrtime()
 			first = false
 		end

--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -189,7 +189,7 @@ function VoiceConnection:_play(stream, duration)
 	local frame_size = SAMPLE_RATE * FRAME_DURATION / MS_PER_S
 	local pcm_len = frame_size * CHANNELS
 
-	local start = hrtime()
+	local first = true
 
 	while elapsed < duration do
 
@@ -214,6 +214,10 @@ function VoiceConnection:_play(stream, duration)
 		local packet = header .. ffi_string(encrypted, encrypted_len)
 		udp:send(packet, ip, port)
 
+		if first then
+			start = hrtime()
+			first = false
+		end
 		elapsed = elapsed + FRAME_DURATION
 		local delay = elapsed - (hrtime() - start) * MS_PER_NS
 		sleep(max(delay, 0))

--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -189,6 +189,7 @@ function VoiceConnection:_play(stream, duration)
 	local frame_size = SAMPLE_RATE * FRAME_DURATION / MS_PER_S
 	local pcm_len = frame_size * CHANNELS
 
+	local start
 	local init = true
 
 	while elapsed < duration do

--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -216,7 +216,7 @@ function VoiceConnection:_play(stream, duration)
 
 		if init then
 			start = hrtime()
-			first = false
+			init = false
 		end
 		elapsed = elapsed + FRAME_DURATION
 		local delay = elapsed - (hrtime() - start) * MS_PER_NS


### PR DESCRIPTION
Sometimes it might take over 800ms from the time that start is declared to the first time delay is calculated. That makes the sleep go down to 0ms for a time to catch up.
Moves the start time to the first loop.