### PR TITLE
Improve message mention parsing

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -36,7 +36,7 @@ local function parseMentions(content)
 	local users, roles, channels, emojis = {}, {}, {}, {}
 	local seen = {}
 
-	for symbol, id in content:gmatch('<%P?(%p+)[^:]-%p?(%d+)>') do
+	for symbol, id in content:gmatch('<%P?(%p+)[%w_]-%p?(%d+)>') do
 		if not seen[id] then
 			if symbol == '@&' then
 				insert(roles, id)

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -36,7 +36,7 @@ local function parseMentions(content)
 	local users, roles, channels, emojis = {}, {}, {}, {}
 	local seen = {}
 
-	for symbol, id in content:gmatch('<.-(%p+)(%d+)>') do
+	for symbol, id in content:gmatch('<%P?(%p+)%w-%p?(%d+)>') do
 		if not seen[id] then
 			if symbol == '@&' then
 				insert(roles, id)

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -36,7 +36,7 @@ local function parseMentions(content)
 	local users, roles, channels, emojis = {}, {}, {}, {}
 	local seen = {}
 
-	for symbol, id in content:gmatch('<%P?(%p+)%w-%p?(%d+)>') do
+	for symbol, id in content:gmatch('<%P?(%p+)[^:]-%p?(%d+)>') do
 		if not seen[id] then
 			if symbol == '@&' then
 				insert(roles, id)


### PR DESCRIPTION
Pattern was tested using
```lua
local function match(str, pat)
    return p(str, str:match(pat))
end

local function test(pat)
    print(pat)
    match('emoji <:name:1234>', pat)
    match('anim  <a:name:1234>', pat)
    match('user  <@1234>', pat)
    match('nick  <@!1234>', pat)
    match('role  <@&1234>', pat)
    match('chan  <#1234>', pat)

    print('Angle Bracket')
    match('< emoji <:name:1234>', pat)
    match('< anim  <a:name:1234>', pat)
    match('< user  <@1234>', pat)
    match('< nick  <@!1234>', pat)
    match('< role  <@&1234>', pat)
    match('< chan  <#1234>', pat)

    print('Punct')
    match('<- emoji <:name:1234>', pat)
    match('<- anim  <a:name:1234>', pat)
    match('<- user  <@1234>', pat)
    match('<- nick  <@!1234>', pat)
    match('<- role  <@&1234>', pat)
    match('<- chan  <#1234>', pat)
    print('')
end

test("<%P?(%p+)%w-%p?(%d+)>")
```

And it yields the output
```
<%P?(%p+)%w-%p?(%d+)>
'emoji <:name:1234>'    ':'     '1234'
'anim  <a:name:1234>'   ':'     '1234'
'user  <@1234>' '@'     '1234'
'nick  <@!1234>'        '@!'    '1234'
'role  <@&1234>'        '@&'    '1234'
'chan  <#1234>' '#'     '1234'
Angle Bracket
'< emoji <:name:1234>'  ':'     '1234'
'< anim  <a:name:1234>' ':'     '1234'
'< user  <@1234>'       '@'     '1234'
'< nick  <@!1234>'      '@!'    '1234'
'< role  <@&1234>'      '@&'    '1234'
'< chan  <#1234>'       '#'     '1234'
Punct
'<- emoji <:name:1234>' ':'     '1234'
'<- anim  <a:name:1234>'        ':'     '1234'
'<- user  <@1234>'      '@'     '1234'
'<- nick  <@!1234>'     '@!'    '1234'
'<- role  <@&1234>'     '@&'    '1234'
'<- chan  <#1234>'      '#'     '1234'
```