### PR TITLE
Lpeg parse mentions

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -1,4 +1,5 @@
 local json = require('json')
+local lpeg = require('lpeg')
 local constants = require('constants')
 local Cache = require('iterables/Cache')
 local ArrayIterable = require('iterables/ArrayIterable')
@@ -7,9 +8,9 @@ local Reaction = require('containers/Reaction')
 local Resolver = require('client/Resolver')
 
 local insert = table.insert
+local rset = rawset
 local null = json.null
 
-local lpeg = require"lpeg"
 local P, V, C, S, Carg, l = lpeg.P, lpeg.V, lpeg.C, lpeg.S, lpeg.Carg, {} 
 lpeg.locale(l)
 
@@ -34,8 +35,8 @@ local open = P"<" -- create the generic pattern objects
 local close = P">"
 local cid = C(l.digit^1)
 local emoji_name = (("_" + l.alnum)  - ":")^1
-local rset = rawset
 local function add_mention(seen, tbl, id) if not seen[id] then return rset(seen, id, true) and insert(tbl, id) end end
+
 local mention_types = {
     emoji = Carg(1) * Carg(2) * ":" * emoji_name * ":" * cid / add_mention, 
     animoji = Carg(1) * Carg(2) * "a:" * emoji_name * ":" * cid / add_mention,
@@ -44,6 +45,7 @@ local mention_types = {
     role = Carg(1) * Carg(4) * "@&" * cid / add_mention,
     channel = Carg(1) * Carg(5) * "#" * cid / add_mention,
 }
+
 local predicate = #(open * S[[a@#:]] * (S[[:!&]] + l.alnum)) --a predicate pattern to allow us to quit early
 
 local mention_patt = open * (

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -38,38 +38,38 @@ local emoji_name = (("_" + l.alnum)  - ":")^1
 local function add_mention(seen, tbl, id) if not seen[id] then return rset(seen, id, true) and insert(tbl, id) end end
 
 local mention_types = {
-    emoji = Carg(1) * Carg(2) * ":" * emoji_name * ":" * cid / add_mention, 
-    animoji = Carg(1) * Carg(2) * "a:" * emoji_name * ":" * cid / add_mention,
-    user = Carg(1) * Carg(3) * "@" * cid / add_mention,
-    nick = Carg(1) * Carg(3) * "@!" * cid / add_mention,
-    role = Carg(1) * Carg(4) * "@&" * cid / add_mention,
-    channel = Carg(1) * Carg(5) * "#" * cid / add_mention,
+	emoji = Carg(1) * Carg(2) * ":" * emoji_name * ":" * cid / add_mention, 
+	animoji = Carg(1) * Carg(2) * "a:" * emoji_name * ":" * cid / add_mention,
+	user = Carg(1) * Carg(3) * "@" * cid / add_mention,
+	nick = Carg(1) * Carg(3) * "@!" * cid / add_mention,
+	role = Carg(1) * Carg(4) * "@&" * cid / add_mention,
+	channel = Carg(1) * Carg(5) * "#" * cid / add_mention,
 }
 
 local predicate = #(open * S[[a@#:]] * (S[[:!&]] + l.alnum)) --a predicate pattern to allow us to quit early
 
 local mention_patt = open * (
-    mention_types.emoji + 
-    mention_types.animoji + 
-    mention_types.user + 
-    mention_types.nick + 
-    mention_types.role + 
-    mention_types.channel
+	mention_types.emoji + 
+	mention_types.animoji + 
+	mention_types.user + 
+	mention_types.nick + 
+	mention_types.role + 
+	mention_types.channel
 ) * close
 
 mention_patt = P{predicate * mention_patt + 1 * V(1)}^1-- a recursive definition that matches multiple mentions which can appear anywhre in the text.
 
 local function parseMentions(text) 
-    local seen = {}
+	local seen = {}
 	local emoji = {}
 	local users = {}
 	local roles = {}
-    local channels = {}
-    local start = text:find('<', 1, true)
-    if start then 
-        mention_patt:match(text, start, seen, emoji, users, roles, channels)
-    end
-    return emoji, users, roles, channels
+	local channels = {}
+	local start = text:find('<', 1, true)
+	if start then 
+		mention_patt:match(text, start, seen, emoji, users, roles, channels)
+	end
+	return emoji, users, roles, channels
 end
 
 function Message:_loadMore(data)


### PR DESCRIPTION
Adds a new parseMention function which can correctly handle all types of mentions, it behaves the same as the previous parseMention; returning arrays of ids as output.

As discussed in  PR [#121](https://github.com/SinisterRectus/Discordia/pull/121) an lpeg based parser seems to be the fastest method to parse mentions accurately. The advantages to lpeg when compared to lrexlib and lua patterns are it's speed and accuracy. 

- The lpeg parser does not need to do any extra filtering and inserts mentions directly into the output arrays as they are found whilst checking for duplicate ids.
- The predicate patterns allow for a quick check before entering the larger pattern groups, this allows it quit parsing early.
- Easier to expand if discord adds new mentionables; the existing patterns are all independent of eachother.

```
The mention string inserted randomly into 100000 bytes of lorem ipsum was: "<@!word:1234><a@!word1234><><<a:#1234>><##1234><a::name:1234><<#1234><<@1234>><@!1234><@&1234<#1234<:name:1234>>><a:name:12344>>>"
This contains 5 correct mentions
Overall there are 34265 mentions within the buffer
buffer_size: 984363
Performing 1000 tests of each method
Finished collecting data
Avg lpeg speed over 1000 tests: 16.633165ms
Avg gmatch speed over 1000 tests: 36.292022ms
Avg rex speed over 1000 tests: 36.292862ms
```

