### PR TITLE
Changed emitted event(s) from MESSAGE_DELETE_BULK

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -89,7 +89,7 @@ end
 local Client, get = require('class')('Client', Emitter)
 
 function Client:__init(options)
-	Emitter.__init(self)
+	self._emitter = Emitter.__init(self)
 	options = parseOptions(options)
 	self._options = options
 	self._shards = {}
@@ -119,7 +119,7 @@ end
 function Client:_deprecated(clsName, before, after)
 	local info = debug.getinfo(3)
 	return self:warning(
-		'%s:%s: %s.%s is deprecated; use %s.%s instead',
+		'%s:%s: %s.%s is deprecated; use %s.%s instead.',
 		info.short_src,
 		info.currentline,
 		clsName,

--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -346,16 +346,18 @@ function EventHandler.MESSAGE_DELETE(d, client) -- message object not provided
 end
 
 function EventHandler.MESSAGE_DELETE_BULK(d, client)
+	local messages = {}
 	local channel = getChannel(client, d.channel_id)
 	if not channel then return warning(client, 'TextChannel', d.channel_id, 'MESSAGE_DELETE_BULK') end
 	for _, id in ipairs(d.ids) do
 		local message = channel._messages:_delete(id)
 		if message then
-			client:emit('messageDelete', message)
+			table.insert(messages, message)
 		else
-			client:emit('messageDeleteUncached', channel, id)
+			table.insert(messages, {id = id, channel = channel, uncached = true})
 		end
 	end
+	return client:emit("messageDeleteBulk", messages)
 end
 
 function EventHandler.MESSAGE_REACTION_ADD(d, client)

--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -352,10 +352,29 @@ function EventHandler.MESSAGE_DELETE_BULK(d, client)
 	for _, id in ipairs(d.ids) do
 		local message = channel._messages:_delete(id)
 		if message then
+			client:emit('messageDelete', message)
 			table.insert(messages, message)
 		else
+			client:emit('messageDeleteUncached', channel, id)
 			table.insert(messages, {id = id, channel = channel, uncached = true})
 		end
+	end
+
+	local deprecatedEvent
+	if client._emitter._listeners["messageDelete"] then
+		deprecatedEvent = "messageDelete"
+	elseif client._emitter._listeners["messageDeleteUncached"] then
+		deprecatedEvent = "messageDeleteUncached"
+	end
+
+	if deprecatedEvent then
+		local info = debug.getinfo(1)
+		client:warning(
+			'%s:%s: The usage of %s for BulkDelete is deprecated; use messageDeleteBulk event instead.',
+			info.short_src,
+			info.currentline,
+			deprecatedEvent
+		)
 	end
 	return client:emit("messageDeleteBulk", messages)
 end

--- a/libs/utils/Emitter.lua
+++ b/libs/utils/Emitter.lua
@@ -11,6 +11,7 @@ local Emitter = require('class')('Emitter')
 
 function Emitter:__init()
 	self._listeners = {}
+	return self
 end
 
 local function new(self, name, listener)


### PR DESCRIPTION
Now emits 'messageDeleteBulk' with a table of message objects (or a basic {id = id, channel = channel, uncached = true} table for those uncached messages).

Simple example:
```lua
client:on("messageDeleteBulk", function(messages)
	print(#messages .. " messages deleted.")

	for _, message in pairs(messages) do
		p("Message author was: " .. message.author.username)
		p("Message ID: " .. message.id)
		p("Message content was : " .. message.content)
		p()
	end
end)
```