### PR TITLE
4003 after outage

### DIFF
--- a/libs/client/WebSocket.lua
+++ b/libs/client/WebSocket.lua
@@ -90,7 +90,11 @@ function WebSocket:_send(op, d)
 	self._mutex:lock()
 	local success, err
 	if self._write then
-		success, err = self._write {opcode = TEXT, payload = encode {op = op, d = d}}
+		if self._session_id then
+			success, err = self._write {opcode = TEXT, payload = encode {op = op, d = d}}
+		else
+			success, err = false, 'Invalid session, sent websocket message without authentication'
+		end
 	else
 		success, err = false, 'Not connected to gateway'
 	end


### PR DESCRIPTION
return error for websocket messages that are sent in the time frame between invalid session and re-identify that trigger 4003 errors from the socket.