### PR TITLE
Fix of fix for 4003 issues

### DIFF
--- a/libs/client/Shard.lua
+++ b/libs/client/Shard.lua
@@ -50,6 +50,16 @@ function Shard:__init(id, client)
 	self._backoff = 1000
 end
 
+local wssend = WebSocket._send 
+
+function Shard:_send(op, d, ignore)
+	if ignore or self._session_id then 
+		return wssend(self, op, d)
+	else
+		return false, 'Invalid session, sent websocket message without authentication'
+	end
+end
+
 for name in pairs(logLevel) do
 	Shard[name] = function(self, fmt, ...)
 		local client = self._client
@@ -211,7 +221,7 @@ function Shard:identify()
 		large_threshold = options.largeThreshold,
 		shard = {self._id, client._total_shard_count},
 		presence = next(client._presence) and client._presence,
-	})
+	}, true)
 
 end
 


### PR DESCRIPTION
Identical behaviour to the previous fix except the bug which prevented `IDENTIFY` from sending is patched, and the `WebSocket` class is left untouched. This moves the fix for a discord issue into the discord specific `Shard` class instead.

It may be preferable to check the gateway OP code but I think the extra argument is a bit more flexible should more issues arrive in the future. 