### PR TITLE
Fixed client

### DIFF
--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -309,7 +309,8 @@ function VoiceConnection:close()
 		self._socket:disconnect()
 	end
 	local guild = self._channel._parent
-	return self._client._shards[guild.shardId]:updateVoice(guild._id)
+	local client = self._parent
+	return client._shards[guild.shardId]:updateVoice(guild._id)
 end
 
 function get.channel(self)


### PR DESCRIPTION
This fixes the following error:
discordia/libs/voice/VoiceConnection.lua:312: attempt to index field '_client' (a nil value)