### PR TITLE
Add Guild:getBan(user)

### DIFF
--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -472,13 +472,13 @@ function API:removeGuildMember(guild_id, user_id, query) -- Guild:kickUser
 	return self:request("DELETE", endpoint, nil, query)
 end
 
-function API:getGuildBan(guild_id, user_id) -- Guild:getBan
-	local endpoint = f(endpoints.GUILD_BAN, guild_id, user_id)
+function API:getGuildBans(guild_id) -- Guild:getBans
+	local endpoint = f(endpoints.GUILD_BANS, guild_id)
 	return self:request("GET", endpoint)
 end
 
-function API:getGuildBans(guild_id) -- Guild:getBans
-	local endpoint = f(endpoints.GUILD_BANS, guild_id)
+function API:getGuildBan(guild_id, user_id) -- Guild:getBan
+	local endpoint = f(endpoints.GUILD_BAN, guild_id, user_id)
 	return self:request("GET", endpoint)
 end
 

--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -472,6 +472,11 @@ function API:removeGuildMember(guild_id, user_id, query) -- Guild:kickUser
 	return self:request("DELETE", endpoint, nil, query)
 end
 
+function API:getGuildBan(guild_id, user_id) -- Guild:getBan
+	local endpoint = f(endpoints.GUILD_BAN, guild_id, user_id)
+	return self:request("GET", endpoint)
+end
+
 function API:getGuildBans(guild_id) -- Guild:getBans
 	local endpoint = f(endpoints.GUILD_BANS, guild_id)
 	return self:request("GET", endpoint)

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -425,6 +425,25 @@ function Guild:pruneMembers(days)
 end
 
 --[=[
+@m getBan
+@p user User-ID-Resolvable | User
+@r Ban
+@d Returns a [ban object](https://discordapp.com/developers/docs/resources/guild#ban-object) for the given user.
+]=]
+function Guild:getBan(user)
+	if user.id then
+		user = Resolver.userId(user.id)
+	end
+
+	local data, err = self.client._api:getGuildBan(self._id, user)
+	if data then
+		return Ban(data, self._parent)
+	else
+		return nil, err
+	end
+end
+
+--[=[
 @m getBans
 @r Cache
 @d Returns a newly constructed cache of all ban objects for the guild. The

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -158,7 +158,7 @@ function Guild:getMember(id)
 end
 
 --[=[
-@m getMember
+@m getRole
 @p id User-ID-Resolvable
 @r Member
 @d Gets a role object by ID.
@@ -425,25 +425,6 @@ function Guild:pruneMembers(days)
 end
 
 --[=[
-@m getBan
-@p user User-ID-Resolvable | User
-@r Ban
-@d Returns a [ban object](https://discordapp.com/developers/docs/resources/guild#ban-object) for the given user.
-]=]
-function Guild:getBan(user)
-	if user.id then
-		user = user.id
-	end
-
-	local data, err = self.client._api:getGuildBan(self._id, user)
-	if data then
-		return Ban(data, self._parent)
-	else
-		return nil, err
-	end
-end
-
---[=[
 @m getBans
 @r Cache
 @d Returns a newly constructed cache of all ban objects for the guild. The
@@ -455,6 +436,24 @@ function Guild:getBans()
 	local data, err = self.client._api:getGuildBans(self._id)
 	if data then
 		return Cache(data, Ban, self)
+	else
+		return nil, err
+	end
+end
+
+--[=[
+@m getBan
+@p user User-ID-Resolvable | User
+@r Ban
+@d Returns a Ban object for the given user. Will return nil when no ban 
+was found for that user.
+]=]
+function Guild:getBan(user)
+	user = Resolver.userId(user)
+
+	local data, err = self.client._api:getGuildBan(self._id, user)
+	if data then
+		return Ban(data, self._parent)
 	else
 		return nil, err
 	end

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -443,15 +443,14 @@ end
 
 --[=[
 @m getBan
-@p user User-ID-Resolvable | User
+@p id User-ID-Resolvable | User
 @r Ban
-@d Returns a Ban object for the given user. Will return nil when no ban 
-was found for that user.
+@d This will return a Ban object for a giver user if that user is banned 
+from the guild; otherwise, `nil` is returned.
 ]=]
-function Guild:getBan(user)
-	user = Resolver.userId(user)
-
-	local data, err = self.client._api:getGuildBan(self._id, user)
+function Guild:getBan(id)
+	id = Resolver.userId(id)
+	local data, err = self.client._api:getGuildBan(self._id, id)
 	if data then
 		return Ban(data, self._parent)
 	else

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -432,7 +432,7 @@ end
 ]=]
 function Guild:getBan(user)
 	if user.id then
-		user = Resolver.userId(user.id)
+		user = user.id
 	end
 
 	local data, err = self.client._api:getGuildBan(self._id, user)


### PR DESCRIPTION
This PR adds the missing function ``Guild:getBan(user)``.

It accepts both, a user ID or a user object.