### PR TITLE
breaking prefix concatenation

### DIFF
--- a/examples/helpCommandExample.lua
+++ b/examples/helpCommandExample.lua
@@ -25,7 +25,7 @@ end)
 client:on("messageCreate", function(message)
 	local args = message.content:split(" ") -- split all arguments into a table
 
-	local command = commands[prefix..args[1]]
+	local command = commands[args[1]]
 	if command then -- ping or hello
 		command.exec(message) -- execute the command
 	end


### PR DESCRIPTION
Fix the redundant and breaking concatenation of prefix in helpCommandExample.lua:28, as args[1] already contains the prefix