### PR TITLE
Add Snowflake.date

### DIFF
--- a/libs/containers/abstract/Snowflake.lua
+++ b/libs/containers/abstract/Snowflake.lua
@@ -35,6 +35,14 @@ function get.createdAt(self)
 	return Date.parseSnowflake(self._id)
 end
 
+--[=[@p date Date A date object representing the time at which the object was created by Discord.
+
+Equivalent to `Date.fromSnowflake(Snowflake.id)`
+]=]
+function get.date(self)
+	return Date.fromSnowflake(self._id)
+end
+
 --[=[@p timestamp string The date and time at which this object was created by Discord, represented as
 an ISO 8601 string plus microseconds when available.
 

--- a/libs/containers/abstract/Snowflake.lua
+++ b/libs/containers/abstract/Snowflake.lua
@@ -37,7 +37,7 @@ end
 
 --[=[@p date Date A date object representing the time at which the object was created by Discord.
 
-Equivalent to `Date.fromSnowflake(Snowflake.id)`
+Equivalent to `Date.fromSnowflake(Snowflake.id)`.
 ]=]
 function get.date(self)
 	return Date.fromSnowflake(self._id)


### PR DESCRIPTION
Adds `Snowflake.date`. This makes computation with "created ats" much more terse if desired and doesnt break the current behaviour. 

#### Example Usage:
```lua
return (msg.date - another_date):toString()
```