### PR TITLE
Fix Member:hasPermission returning false in some conditions for admins

### DIFF
--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -108,15 +108,15 @@ function Member:hasPermission(channel, perm)
 		return true
 	end
 
-	local rolePermission = guild.defaultRole.permissions
+	local rolePermissions = guild.defaultRole.permissions
 
 	for role in self.roles:iter() do
 		if role.id ~= guild.id then -- just in case
-			rolePermission = bor(rolePermission, role.permissions)
+			rolePermissions = bor(rolePermissions, role.permissions)
 		end
 	end
 
-	if band(rolePermission, permission.administrator) > 0 then
+	if has(rolePermissions, permission.administrator) then
 		return true
 	end
 
@@ -164,7 +164,7 @@ function Member:hasPermission(channel, perm)
 
 	end
 
-	return has(rolePermission, n)
+	return has(rolePermissions, n)
 
 end
 

--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -71,8 +71,8 @@ function Member:getColor()
 	return roles[1] and roles[1]:getColor() or Color()
 end
 
-local function has(a, b, admin)
-	return band(a, b) > 0 or admin and band(a, permission.administrator) > 0
+local function has(a, b)
+	return band(a, b) > 0
 end
 
 --[=[
@@ -105,6 +105,18 @@ function Member:hasPermission(channel, perm)
 	end
 
 	if self.id == guild.ownerId then
+		return true
+	end
+
+	local rolePermission = guild.defaultRole.permissions
+
+	for role in self.roles:iter() do
+		if role.id ~= guild.id then -- just in case
+			rolePermission = bor(rolePermission, role.permissions)
+		end
+	end
+
+	if band(rolePermission, permission.administrator) > 0 then
 		return true
 	end
 
@@ -152,19 +164,7 @@ function Member:hasPermission(channel, perm)
 
 	end
 
-	for role in self.roles:iter() do
-		if role.id ~= guild.id then -- just in case
-			if has(role.permissions, n, true) then
-				return true
-			end
-		end
-	end
-
-	if has(guild.defaultRole.permissions, n, true) then
-		return true
-	end
-
-	return false
+	return has(rolePermission, n)
 
 end
 


### PR DESCRIPTION
Like if channel disallow everyone to see it, it would return false for the read permission, even for admins.

To reproduce the bug:
- Have a channel disallowing everyone from reading/writing in it
- Test if an admin has the read/write permission on that channel with Member:hasPermission

because channel overwrites permissions are checked before admin rights, this will return false (and should return true because admins do have all rights, well almost all rights).