### PR TITLE
Made emoji capture less greedy

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -400,7 +400,7 @@ function get.cleanContent(self)
 			:gsub('<@!?(%d+)>', users)
 			:gsub('<@&(%d+)>', roles)
 			:gsub('<#(%d+)>', channels)
-			:gsub('<a?:[%w_]+:(%d+)>', '%1')
+			:gsub('<a?(:[%w_]+:)%d+>', '%1')
 			:gsub('@everyone', everyone)
 			:gsub('@here', here)
 

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -400,7 +400,7 @@ function get.cleanContent(self)
 			:gsub('<@!?(%d+)>', users)
 			:gsub('<@&(%d+)>', roles)
 			:gsub('<#(%d+)>', channels)
-			:gsub('<a?(:[%w_][%w_]+:)%d+>', '%1')
+			:gsub('<a?:[%w_]+:(%d+)>', '%1')
 			:gsub('@everyone', everyone)
 			:gsub('@here', here)
 

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -400,7 +400,7 @@ function get.cleanContent(self)
 			:gsub('<@!?(%d+)>', users)
 			:gsub('<@&(%d+)>', roles)
 			:gsub('<#(%d+)>', channels)
-			:gsub('<a?(:.+:)%d+>', '%1')
+			:gsub('<a?(:[%w_][%w_]+:)%d+>', '%1')
 			:gsub('@everyone', everyone)
 			:gsub('@here', here)
 


### PR DESCRIPTION
Discord emojis are 2+ characters long with alphanumeric characters and underscores. The `.+` capture resulted in unintended consequences when there was more than one emoji in the message.