### PR TITLE
Add permission `stream`.

### DIFF
--- a/libs/enums.lua
+++ b/libs/enums.lua
@@ -127,6 +127,7 @@ enums.permission = enum {
 	addReactions        = 0x00000040,
 	viewAuditLog        = 0x00000080,
 	prioritySpeaker     = 0x00000100,
+	stream              = 0x00000200,
 	readMessages        = 0x00000400,
 	sendMessages        = 0x00000800,
 	sendTextToSpeech    = 0x00001000,


### PR DESCRIPTION

This is mentioned in discordapp/discord-api-docs#918. `Permissions.stream` is for Discord's upcoming guild video feature. A reference can also be found in the [Discord Datamining repo](https://github.com/DJScias/Discord-Datamining/commit/3ae3f7f301b31bac66a1e0ed18f67e540b32fdff).

Previously, there was no bit assigned to ``0x00000200``. 