### PR TITLE
Implement guildSubscriptions for bots.

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -67,6 +67,7 @@ local defaultOptions = {
 	gatewayFile = 'gateway.json',
 	dateTime = '%F %T',
 	syncGuilds = false,
+	guildSubscriptions = true,
 }
 
 local function parseOptions(customOptions)

--- a/libs/client/Shard.lua
+++ b/libs/client/Shard.lua
@@ -215,6 +215,7 @@ function Shard:identify()
 		large_threshold = options.largeThreshold,
 		shard = {self._id, client._total_shard_count},
 		presence = next(client._presence) and client._presence,
+		guild_subscriptions = options.guildSubscriptions,
 	}, true)
 
 end


### PR DESCRIPTION
This allows you to opt out of guild update events, such as `presenceUpdate`. More information is available at discordapp/discord-api-docs#1016.

```lua
local client = discordia.Client {guildSubscriptions = true}

client:on("presenceUpdate", function(member)
	print(member) -- won't print anything because it will never receive a presence update
end)
```

