### PR TITLE
fix: Invite.createdAt and Webhook:getDefaultAvatarURL

### DIFF
--- a/libs/containers/Invite.lua
+++ b/libs/containers/Invite.lua
@@ -51,7 +51,7 @@ function get:temporary()
 end
 
 function get:createdAt()
-	return self._createdAt
+	return self._created_at
 end
 
 function get:approximatePresenceCount()

--- a/libs/containers/Webhook.lua
+++ b/libs/containers/Webhook.lua
@@ -27,8 +27,8 @@ function Webhook:getAvatarURL(size, ext)
 	return User.getAvatarURL(self, size, ext)
 end
 
-function Webhook:getDefaultAvatarURL(size)
-	return User.getDefaultAvatarURL(self, size)
+function Webhook:getDefaultAvatarURL(size, ext)
+	return User.getDefaultAvatarURL(self, size, ext)
 end
 
 function Webhook:setName(name)


### PR DESCRIPTION
* Invite.createdAt used `self._createdAt` instead of `self._created_at`

* Webhook:getDefaultAvatarURL was missing a parameter