### PR TITLE
Add an implementation for Activity.__hash

### DIFF
--- a/libs/containers/Activity.lua
+++ b/libs/containers/Activity.lua
@@ -39,6 +39,11 @@ function Activity:_loadMore(data)
 	self._emoji_animated = emoji and emoji.animated
 end
 
+--[=[
+@m __hash
+@r string
+@d Returns `Activity.type .. Activity.parent:__hash()`
+]=]
 function Activity:__hash()
 	return format("%i%s", self._type, self._parent:__hash())
 end

--- a/libs/containers/Activity.lua
+++ b/libs/containers/Activity.lua
@@ -42,10 +42,10 @@ end
 --[=[
 @m __hash
 @r string
-@d Returns `Activity.type .. Activity.parent:__hash()`
+@d Returns `Activity.parent:__hash()`
 ]=]
 function Activity:__hash()
-	return format("%i%s", self._type, self._parent:__hash())
+	return self._parent:__hash()
 end
 
 --[=[@p start number/nil The Unix timestamp for when this Rich Presence activity was started.]=]

--- a/libs/containers/Activity.lua
+++ b/libs/containers/Activity.lua
@@ -39,6 +39,10 @@ function Activity:_loadMore(data)
 	self._emoji_animated = emoji and emoji.animated
 end
 
+function Activity:__hash()
+	return format("%i%s", self._type, self._parent:__hash())
+end
+
 --[=[@p start number/nil The Unix timestamp for when this Rich Presence activity was started.]=]
 function get.start(self)
 	return self._start


### PR DESCRIPTION
As a consequence of issue #140, `tostring(Activity)` (and `print(Activity)` as a result) causes Luvit to exit without an error code or stacktrace. Your guess as to why it crashes is as good as mine, but given the nature of the crash, it seems like it would be a good idea to add a `__hash` implementation now rather than waiting for 3.0.

This implementation optimistically assumes there will only be one activity type per member at a time, which as far as I know should be the case. If that's not the case, let me know and I'll close this PR.