### PR TITLE
Fix Date.fromISO not reading timezone

### DIFF
--- a/libs/utils/Date.lua
+++ b/libs/utils/Date.lua
@@ -44,6 +44,7 @@ local properties = { -- name, pattern, default
 	{'min', '%d%d%d%d%-%d%d%-%d%d.%d%d:(%d%d)', 0},
 	{'sec', '%d%d%d%d%-%d%d%-%d%d.%d%d:%d%d:(%d%d)', 0},
 	{'usec', '%d%d%d%d%-%d%d%-%d%d.%d%d:%d%d:%d%d.(%d%d%d%d%d%d)', 0},
+	{'zone', '%d%d%d%d%-%d%d%-%d%d.%d%d:%d%d:%d%d.%d%d%d%d%d%d([+-]%d%d):%d%d', 0}
 }
 
 local function toTime(tbl, utc)

--- a/tests/test-date.lua
+++ b/tests/test-date.lua
@@ -83,9 +83,9 @@ assertEqual(Date.fromISO('2020-03-13T20:54:47.234567'), Date.fromTableUTC {
 	year = 2020, month = 3, day = 13,
 	hour = 20, min = 54, sec = 47, usec = 234567,
 })
-assertEqual(Date.fromISO('2020-03-13T20:54:47.234567+03:00'), Date.fromTableUTC {
+assertEqual(Date.fromISO('2020-03-13T20:54:47.234567-03:00'), Date.fromTableUTC {
 	year = 2020, month = 3, day = 13,
-	hour = 20, min = 54, sec = 47, usec = 234567, zone = "+03:00"
+	hour = 20, min = 54, sec = 47, usec = 234567, zone = -3
 })
 
 assertTrue(Date(1) == Date(1))

--- a/tests/test-date.lua
+++ b/tests/test-date.lua
@@ -83,6 +83,10 @@ assertEqual(Date.fromISO('2020-03-13T20:54:47.234567'), Date.fromTableUTC {
 	year = 2020, month = 3, day = 13,
 	hour = 20, min = 54, sec = 47, usec = 234567,
 })
+assertEqual(Date.fromISO('2020-03-13T20:54:47.234567+03:00'), Date.fromTableUTC {
+	year = 2020, month = 3, day = 13,
+	hour = 20, min = 54, sec = 47, usec = 234567, zone = "+03:00"
+})
 
 assertTrue(Date(1) == Date(1))
 assertTrue(Date(1) ~= Date(2))


### PR DESCRIPTION
Doesn't support minutes offset, but at least it reads hours and doesn't error on Discord timestamps like `guild.joined_at`.