### PR TITLE
Specifies the use of a bot token.

### DIFF
--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -118,7 +118,7 @@ function API:__init(client)
 end
 
 function API:authenticate(token)
-	self._token = token
+	self._token = "Bot " .. token
 	return self:getCurrentUser()
 end
 


### PR DESCRIPTION
Discord has changed it to where in authorization needs a differential between bot and bearer tokens. This fix allows for the bot to again access the API without errors.