### PR TITLE
Fix issue with Message.lua causing bot to crash

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -122,10 +122,11 @@ end
 function Message:_removeReaction(d)
 
 	local reactions = self._reactions
-
+	if not reactions then return nil end
+	
 	local emoji = d.emoji
 	local k = emoji.id ~= null and emoji.id or emoji.name
-	local reaction = reactions and reactions:get(k) or nil
+	local reaction = reactions:get(k) or nil
 	
 	if not reaction then return nil end -- uncached reaction?
 

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -125,9 +125,10 @@ function Message:_removeReaction(d)
 
 	local emoji = d.emoji
 	local k = emoji.id ~= null and emoji.id or emoji.name
-	local reaction = reactions:get(k)
-
+	
 	if not reaction then return nil end -- uncached reaction?
+	
+	local reaction = reactions:get(k)
 
 	reaction._count = reaction._count - 1
 	if d.user_id == self.client._user._id then

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -125,10 +125,9 @@ function Message:_removeReaction(d)
 
 	local emoji = d.emoji
 	local k = emoji.id ~= null and emoji.id or emoji.name
+	local reaction = reactions and reactions:get(k) or nil
 	
 	if not reaction then return nil end -- uncached reaction?
-	
-	local reaction = reactions:get(k)
 
 	reaction._count = reaction._count - 1
 	if d.user_id == self.client._user._id then


### PR DESCRIPTION
This fixes an issue with my friend's bot where `reaction` is nil and causes the bot to crash. The check should be before the definition of `reaction` to fix the issue.