### PR TITLE
Adds basic support for message replies

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -90,6 +90,10 @@ function Message:_loadMore(data)
 		self._attachments = #data.attachments > 0 and data.attachments or nil
 	end
 
+	if data.referenced_message and data.referenced_message ~= null then
+		self._referencedMessage = self._parent._messages:_insert(data.referenced_message)
+	end
+
 end
 
 function Message:_addReaction(d)
@@ -123,11 +127,11 @@ function Message:_removeReaction(d)
 
 	local reactions = self._reactions
 	if not reactions then return nil end
-	
+
 	local emoji = d.emoji
 	local k = emoji.id ~= null and emoji.id or emoji.name
 	local reaction = reactions:get(k) or nil
-	
+
 	if not reaction then return nil end -- uncached reaction?
 
 	reaction._count = reaction._count - 1
@@ -564,6 +568,12 @@ Equivalent to `Message.guild.members:get(Message.author.id)`.]=]
 function get.member(self)
 	local guild = self.guild
 	return guild and guild._members:get(self._author._id)
+end
+
+--[=[@p referencedMessage Message/nil If available, the previous message that
+this current message references as seen in replies.]=]
+function get.referencedMessage(self)
+	return self._referencedMessage
 end
 
 --[=[@p link string URL that can be used to jump-to the message in the Discord client.]=]

--- a/libs/containers/abstract/TextChannel.lua
+++ b/libs/containers/abstract/TextChannel.lua
@@ -277,11 +277,19 @@ function TextChannel:send(content)
 			end
 		end
 
+		local refMessage, refMention
+		if tbl.reference then
+			refMessage = {message_id = Resolver.messageId(tbl.reference.message)}
+			refMention = {replied_user = not not tbl.reference.mention}
+		end
+
 		data, err = self.client._api:createMessage(self._id, {
 			content = content,
 			tts = tbl.tts,
 			nonce = tbl.nonce,
 			embed = tbl.embed,
+			message_reference = refMessage,
+			allowed_mentions = refMention,
 		}, files)
 
 	else


### PR DESCRIPTION
Example usage:

```lua
local channel = client:getChannel("430492262758088712")

local msgA = assert(channel:send("hello"))

local msgB = assert(channel:send {
  content = "world",
  reference = {message = msgA, mention = true},
})

assert(msgA.content == msgB.referencedMessage.content)
```
![image](https://user-images.githubusercontent.com/11720541/118872783-f5a93d80-b8b6-11eb-8e68-f9106406de5a.png)
