### PR TITLE
fix mentionedUsers error on reply with no mentions

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -41,7 +41,7 @@ function Message:_load(data)
 end
 
 local function parseMentions(content, pattern)
-	if not content:find('%b<>') then return end
+	if not content:find('%b<>') then return {} end
 	local mentions, seen = {}, {}
 	for id in content:gmatch(pattern) do
 		if not seen[id] then


### PR DESCRIPTION
mentionedUsers uses `parseMentions` to obtain a table of mentioned users in the message and then adds the reply target to that table if the message is a reply. This fails when the message contains no mentions (fails `%b<>`) and the message is a reply. This fixes the issue by having `parseMentions` return an empty table in such the case.