### PR TITLE
class.mixin returns the target table

### DIFF
--- a/libs/class.lua
+++ b/libs/class.lua
@@ -56,6 +56,7 @@ local function mixin(target, source)
 	for k, v in pairs(source) do
 		target[k] = v
 	end
+	return target
 end
 
 local function isInit(class, fn)


### PR DESCRIPTION
Currently, `class.mixin()` returns no values. By having it return the `target` argument, the code
```lua
local myMixin = {}
class.mixin(myMixin, someOtherMixin)
```
can be rewritten much more neatly as
```lua
local myMixin = class.mixin({}, someOtherMixin)
```