### PR TITLE
Added Stage Channels, new enums, messageDeleteBulk event, and property setters.

### DIFF
--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -631,6 +631,26 @@ function API:listVoiceRegions() -- Client:listVoiceRegions
 	return self:request("GET", endpoint)
 end
 
+function API:createStageInstance(payload) -- GuildStageChannel:createInstance
+	local endpoint = endpoints.STAGE_INSTANCES
+	return self:request("POST", endpoint, payload)
+end
+
+function API:getStageInstance(channel_id) -- GuildStageChannel:getInstance
+	local endpoint = f(endpoints.STAGE_INSTANCE, channel_id)
+	return self:request("GET", endpoint)
+end
+
+function API:modifyStageInstance(channel_id, payload) -- StageInstance:_modify
+	local endpoint = f(endpoints.STAGE_INSTANCE, channel_id)
+	return self:request("PATCH", endpoint, payload)
+end
+
+function API:deleteStageInstance(channel_id) -- GuildStageChannel:deleteInstance / StageInstance:delete
+	local endpoint = f(endpoints.STAGE_INSTANCE, channel_id)
+	return self:request("DELETE", endpoint)
+end
+
 function API:createWebhook(channel_id, payload) -- GuildTextChannel:createWebhook
 	local endpoint = f(endpoints.CHANNEL_WEBHOOKS, channel_id)
 	return self:request("POST", endpoint, payload)
@@ -689,6 +709,16 @@ end
 function API:executeGitHubCompatibleWebhook(webhook_id, webhook_token, payload) -- not exposed, needs webhook client
 	local endpoint = f(endpoints.WEBHOOK_TOKEN_GITHUB, webhook_id, webhook_token)
 	return self:request("POST", endpoint, payload)
+end
+
+function API:modifyUserVoiceState(guild_id, user_id, payload) -- Member:setVoiceState
+	local endpoint = f(endpoints.GUILD_VOICE_STATE, guild_id, user_id)
+	return self:request("PATCH", endpoint, payload)
+end
+
+function API:modifyCurrentUserVoiceState(guild_id, payload) -- not exposed, maybe in the future
+	local endpoint = f(endpoints.GUILD_VOICE_STATE_ME, guild_id)
+	return self:request("PATCH", endpoint, payload)
 end
 
 function API:getGateway() -- Client:run

--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -348,14 +348,19 @@ end
 function EventHandler.MESSAGE_DELETE_BULK(d, client)
 	local channel = getChannel(client, d.channel_id)
 	if not channel then return warning(client, 'TextChannel', d.channel_id, 'MESSAGE_DELETE_BULK') end
+	local messages = {}
 	for _, id in ipairs(d.ids) do
 		local message = channel._messages:_delete(id)
 		if message then
-			client:emit('messageDelete', message)
+			table.insert(messages,message)
 		else
 			client:emit('messageDeleteUncached', channel, id)
 		end
 	end
+	table.sort(messages,function(a,b)
+		return a.id < b.id
+	end)
+	client:emit('messageDeleteBulk', channel, messages)
 end
 
 function EventHandler.MESSAGE_REACTION_ADD(d, client)

--- a/libs/containers/Emoji.lua
+++ b/libs/containers/Emoji.lua
@@ -11,7 +11,7 @@ local json = require('json')
 
 local format = string.format
 
-local Emoji, get = require('class')('Emoji', Snowflake)
+local Emoji, get, set = require('class')('Emoji', Snowflake)
 
 function Emoji:__init(data, parent)
 	Snowflake.__init(self, data, parent)
@@ -112,6 +112,10 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p guild Guild The guild in which the emoji exists.]=]
 function get.guild(self)
 	return self._parent
@@ -163,6 +167,10 @@ function get.roles(self)
 		self._roles_raw = nil
 	end
 	return self._roles
+end
+
+function set.roles(self, value)
+	return self:setRoles(value)
 end
 
 return Emoji

--- a/libs/containers/GroupChannel.lua
+++ b/libs/containers/GroupChannel.lua
@@ -13,7 +13,7 @@ local Resolver = require('client/Resolver')
 
 local format = string.format
 
-local GroupChannel, get = require('class')('GroupChannel', TextChannel)
+local GroupChannel, get, set = require('class')('GroupChannel', TextChannel)
 
 function GroupChannel:__init(data, parent)
 	TextChannel.__init(self, data, parent)
@@ -98,6 +98,10 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p ownerId string The Snowflake ID of the user that owns (created) the channel.]=]
 function get.ownerId(self)
 	return self._owner_id
@@ -111,6 +115,10 @@ end
 --[=[@p icon string/nil The hash for the channel's custom icon, if one is set.]=]
 function get.icon(self)
 	return self._icon
+end
+
+function set.icon(self, value)
+	return self:setIcon(value)
 end
 
 --[=[@p iconURL string/nil The URL that can be used to view the channel's icon, if one is set.]=]

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -25,7 +25,7 @@ local channelType = enums.channelType
 local floor = math.floor
 local format = string.format
 
-local Guild, get = require('class')('Guild', Snowflake)
+local Guild, get, set = require('class')('Guild', Snowflake)
 
 function Guild:__init(data, parent)
 	Snowflake.__init(self, data, parent)
@@ -701,9 +701,17 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p icon string/nil The hash for the guild's custom icon, if one is set.]=]
 function get.icon(self)
 	return self._icon
+end
+
+function set.icon(self, value)
+	return self:setIcon(value)
 end
 
 --[=[@p iconURL string/nil The URL that can be used to view the guild's icon, if one is set.]=]
@@ -718,6 +726,10 @@ function get.splash(self)
 	return self._splash
 end
 
+function set.splash(self, value)
+	return self:setSplash(value)
+end
+
 --[=[@p splashURL string/nil The URL that can be used to view the guild's custom splash image, if one is set.
 Only partnered guilds may have this.]=]
 function get.splashURL(self)
@@ -728,6 +740,10 @@ end
 --[=[@p banner string/nil The hash for the guild's custom banner, if one is set.]=]
 function get.banner(self)
 	return self._banner
+end
+
+function set.banner(self, value)
+	return self:setBanner(value)
 end
 
 --[=[@p bannerURL string/nil The URL that can be used to view the guild's banner, if one is set.]=]
@@ -750,6 +766,10 @@ end
 --[=[@p region string The voice region that is used for all voice connections in the guild.]=]
 function get.region(self)
 	return self._region
+end
+
+function set.region(self, value)
+	return self:setRegion(value)
 end
 
 --[=[@p vanityCode string/nil The guild's vanity invite URL code, if one exists.]=]
@@ -790,6 +810,10 @@ function get.afkTimeout(self)
 	return self._afk_timeout
 end
 
+function set.afkTimeout(self, value)
+	return self:setAFKTimeout(value)
+end
+
 --[=[@p unavailable boolean Whether the guild is unavailable. If the guild is unavailable, then no property
 is guaranteed to exist except for this one and the guild's ID.]=]
 function get.unavailable(self)
@@ -808,16 +832,28 @@ function get.verificationLevel(self)
 	return self._verification_level
 end
 
+function set.verificationLevel(self, value)
+	return self:setVerificationLevel(value)
+end
+
 --[=[@p notificationSetting number The guild's default notification setting. See the `notficationSetting`
 enumeration for a human-readable representation.]=]
 function get.notificationSetting(self)
 	return self._default_message_notifications
 end
 
+function set.notificationSetting(self, value)
+	return self:setNotificationSetting(value)
+end
+
 --[=[@p explicitContentSetting number The guild's explicit content level setting. See the `explicitContentLevel`
 enumeration for a human-readable representation.]=]
 function get.explicitContentSetting(self)
 	return self._explicit_content_filter
+end
+
+function set.explicitContentSetting(self, value)
+	return self:setExplicitContentSetting(value)
 end
 
 --[=[@p premiumTier number The guild's premier tier affected by nitro server
@@ -847,9 +883,17 @@ function get.owner(self)
 	return self._members:get(self._owner_id)
 end
 
+function set.owner(self, value)
+	return self:setOwner(value)
+end
+
 --[=[@p ownerId string The Snowflake ID of the guild member that owns the guild.]=]
 function get.ownerId(self)
 	return self._owner_id
+end
+
+function set.ownerId(self, value)
+	return self:setOwner(value)
 end
 
 --[=[@p afkChannelId string/nil The Snowflake ID of the channel that is used for AFK members, if one is set.]=]
@@ -857,9 +901,17 @@ function get.afkChannelId(self)
 	return self._afk_channel_id
 end
 
+function set.afkChannelId(self, value)
+	return self:setAFKChannel(value)
+end
+
 --[=[@p afkChannel GuildVoiceChannel/nil Equivalent to `Guild.voiceChannels:get(Guild.afkChannelId)`.]=]
 function get.afkChannel(self)
 	return self._voice_channels:get(self._afk_channel_id)
+end
+
+function set.afkChannel(self, value)
+	return self:setAFKChannel(value)
 end
 
 --[=[@p systemChannelId string/nil The channel id where Discord's join messages will be displayed.]=]
@@ -867,9 +919,17 @@ function get.systemChannelId(self)
 	return self._system_channel_id
 end
 
+function set.systemChannelId(self, value)
+	return self:setSystemChannel(value)
+end
+
 --[=[@p systemChannel GuildTextChannel/nil The channel where Discord's join messages will be displayed.]=]
 function get.systemChannel(self)
 	return self._text_channels:get(self._system_channel_id)
+end
+
+function set.systemChannel(self, value)
+	return self:setSystemChannel(value)
 end
 
 --[=[@p defaultRole Role Equivalent to `Guild.roles:get(Guild.id)`.]=]

--- a/libs/containers/GuildCategoryChannel.lua
+++ b/libs/containers/GuildCategoryChannel.lua
@@ -58,6 +58,27 @@ function GuildCategoryChannel:createVoiceChannel(name)
 	end
 end
 
+--[=[
+@m createStageChannel
+@t http
+@p name string
+@r GuildStageChannel
+@d Creates a new GuildStageChannel with this category as it's parent. Similar to `Guild:createStageChannel(name)`
+]=]
+function GuildCategoryChannel:createStageChannel(name)
+	local guild = self._parent
+	local data, err = guild.client._api:createGuildChannel(guild._id, {
+		name = name,
+		type = channelType.stage,
+		parent_id = self._id
+	})
+	if data then
+		return guild._stage_channels:_insert(data)
+	else
+		return nil, err
+	end
+end
+
 --[=[@p textChannels FilteredIterable Iterable of all textChannels in the Category.]=]
 function get.textChannels(self)
 	if not self._text_channels then

--- a/libs/containers/GuildStageChannel.lua
+++ b/libs/containers/GuildStageChannel.lua
@@ -1,0 +1,123 @@
+--[=[
+@c GuildStageChannel x GuildVoiceChannel
+@d Represents a stage channel in a Discord guild, where stage moderators can host
+events with an audience.
+]=]
+
+local json = require('json')
+
+local GuildVoiceChannel = require('containers/GuildVoiceChannel')
+local StageInstance = require('voice/StageInstance')
+
+local GuildStageChannel, get, set = require('class')('GuildStageChannel', GuildVoiceChannel)
+
+function GuildStageChannel:__init(data, parent)
+	GuildVoiceChannel.__init(self, data, parent)
+	return self:_loadMore(data)
+end
+
+function GuildStageChannel:_load(data)
+	GuildVoiceChannel._load(self, data)
+	return self:_loadMore(data)
+end
+
+function GuildStageChannel:_loadMore(data)
+    local d = self.client._api:getStageInstance(data.id)
+    if d then
+        self._instance = StageInstance(d, self)
+    end
+end
+
+--[=[
+@m setTopic
+@t http
+@p topic string
+@r boolean
+@d Sets the channel's topic. This must be between 1 and 1024 characters. Pass `nil`
+to remove the topic.
+]=]
+function GuildStageChannel:setTopic(topic)
+	return self:_modify({topic = topic or json.null})
+end
+
+--[=[
+@m getInstance
+@t http
+@r StageInstance
+@d Gets the Stage instance associated with the Stage channel, if it exists. If the object is already cached, then the cached
+object will be returned; otherwise, an HTTP request is made.
+]=]
+function GuildStageChannel:getInstance()
+	local instance = self._instance
+	if instance then
+		return instance
+	else
+		local data, err = self.client._api:getStageInstance(self._id)
+		if data then
+			instance = StageInstance(data, self)
+			self._instance = instance
+			return instance
+		else
+			return nil, err
+		end
+	end
+end
+
+--[=[
+@m createInstance
+@t http
+@p topic string (1-120 characters)
+@p privacyLevel number (default 2)
+@r StageInstance
+@d Creates a new Stage instance associated to a Stage channel.
+]=]
+function GuildStageChannel:createInstance(topic, privacyLevel)
+	local instance = self.instance
+	if instance then
+		instance:setTopic(topic)
+		instance:setPrivacyLevel(privacyLevel)
+		return instance
+	else
+		local data, err = self.client._api:createStageInstance({channel_id = self._id, topic = topic, privacy_level = privacyLevel})
+		if data then
+			self._instance = StageInstance(data, self)
+			return self._instance
+		else
+			return nil, err
+		end
+	end
+end
+
+--[=[
+@m deleteInstance
+@t http
+@p topic string (1-120 characters)
+@p privacyLevel number (default 2)
+@r StageInstance
+@d Deletes the Stage instance currently associated to a Stage channel.
+]=]
+function GuildStageChannel:deleteInstance()
+	local data, err = self.client._api:deleteStageInstance(self._id)
+	if data then
+        self._instance = nil
+		return true
+	else
+		return false, err
+	end
+end
+
+--[=[@p instance StageInstance/nil The StageInstance for this channel if one exists.]=]
+function get.instance(self)
+	return self:getInstance()
+end
+
+--[=[@p topic string/nil The channel's topic. This should be between 1 and 1024 characters.]=]
+function get.topic(self)
+	return self._topic
+end
+
+function set.topic(self, value)
+	return self:setTopic(value)
+end
+
+return GuildStageChannel

--- a/libs/containers/GuildVoiceChannel.lua
+++ b/libs/containers/GuildVoiceChannel.lua
@@ -16,6 +16,10 @@ function GuildVoiceChannel:__init(data, parent)
 	GuildChannel.__init(self, data, parent)
 end
 
+function GuildVoiceChannel:_load(data)
+	GuildChannel._load(self, data)
+end
+
 --[=[
 @m setBitrate
 @t http

--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -21,7 +21,7 @@ local band, bor, bnot = bit.band, bit.bor, bit.bnot
 local isInstance = class.isInstance
 local permission = enums.permission
 
-local Member, get = class('Member', UserPresence)
+local Member, get, set = class('Member', UserPresence)
 
 function Member:__init(data, parent)
 	UserPresence.__init(self, data, parent)
@@ -488,6 +488,10 @@ function get.nickname(self)
 	return self._nick
 end
 
+function set.nickname(self, value)
+	return self:setNickname(value)
+end
+
 --[=[@p joinedAt string/nil The date and time at which the current member joined the guild, represented as
 an ISO 8601 string plus microseconds when available. Member objects generated
 via presence updates lack this property.]=]
@@ -508,16 +512,36 @@ function get.voiceChannel(self)
 	return state and guild._voice_channels:get(state.channel_id)
 end
 
+function set.voiceChannel(self, value)
+	return self:setVoiceChannel(value)
+end
+
 --[=[@p muted boolean Whether the member is voice muted in its guild.]=]
 function get.muted(self)
 	local state = self._parent._voice_states[self:__hash()]
 	return state and (state.mute or state.self_mute) or self._mute
 end
 
+function set.muted(self, value)
+	if value == true then
+		return self:mute()
+	elseif value == false then
+		return self:unmute()
+	end
+end
+
 --[=[@p deafened boolean Whether the member is voice deafened in its guild.]=]
 function get.deafened(self)
 	local state = self._parent._voice_states[self:__hash()]
 	return state and (state.deaf or state.self_deaf) or self._deaf
+end
+
+function set.deafened(self, value)
+	if value == true then
+		return self:deafen()
+	elseif value == false then
+		return self:undeafen()
+	end
 end
 
 --[=[@p guild Guild The guild in which this member exists.]=]
@@ -535,6 +559,13 @@ function get.highestRole(self)
 		end
 	end
 	return ret or self.guild.defaultRole
+end
+
+--[=[@p color Color The color object that represents the member's color as determined by
+its highest colored role. If the member has no colored roles, then the default
+color with a value of 0 is returned.]=]
+function get.color(self)
+	return self:getColor()
 end
 
 return Member

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -19,7 +19,7 @@ local format = string.format
 local messageFlag = enums.messageFlag
 local band, bor, bnot = bit.band, bit.bor, bit.bnot
 
-local Message, get = require('class')('Message', Snowflake)
+local Message, get, set = require('class')('Message', Snowflake)
 
 function Message:__init(data, parent)
 	Snowflake.__init(self, data, parent)
@@ -527,6 +527,10 @@ function get.content(self)
 	return self._content
 end
 
+function set.content(self, value)
+	return self:setContent(value)
+end
+
 --[=[@p author User The object of the user that created the message.]=]
 function get.author(self)
 	return self._author
@@ -547,6 +551,10 @@ end
 message. See the Discord documentation for more information.]=]
 function get.embed(self)
 	return self._embeds and self._embeds[1]
+end
+
+function set.embed(self, value)
+	return self:setEmbed(value)
 end
 
 --[=[@p attachment table/nil A raw data table that represents the first file attachment that exists in this

--- a/libs/containers/Role.lua
+++ b/libs/containers/Role.lua
@@ -16,7 +16,7 @@ local insert, sort = table.insert, table.sort
 local min, max, floor = math.min, math.max, math.floor
 local huge = math.huge
 
-local Role, get = require('class')('Role', Snowflake)
+local Role, get, set = require('class')('Role', Snowflake)
 
 function Role:__init(data, parent)
 	Snowflake.__init(self, data, parent)
@@ -313,9 +313,25 @@ function get.hoisted(self)
 	return self._hoist
 end
 
+function set.hoisted(self, value)
+	if value == true then
+		return self:hoist()
+	elseif value == false then
+		return self:unhoist()
+	end
+end
+
 --[=[@p mentionable boolean Whether this role can be mentioned in a text channel message.]=]
 function get.mentionable(self)
 	return self._mentionable
+end
+
+function set.mentionable(self, value)
+	if value == true then
+		return self:enableMentioning()
+	elseif value == false then
+		return self:disableMentioning()
+	end
 end
 
 --[=[@p managed boolean Whether this role is managed by some integration or bot inclusion.]=]
@@ -328,6 +344,10 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p position number The position of the role, where 0 is the lowest.]=]
 function get.position(self)
 	return self._position
@@ -338,9 +358,17 @@ function get.color(self)
 	return self._color
 end
 
+function set.color(self, value)
+	return self:setColor(value)
+end
+
 --[=[@p permissions number Represents the total permissions of the role as a decimal value.]=]
 function get.permissions(self)
 	return self._permissions
+end
+
+function set.permissions(self, value)
+	return self:setPermissions(value)
 end
 
 --[=[@p mentionString string A string that, when included in a message content, may resolve as a role

--- a/libs/containers/Webhook.lua
+++ b/libs/containers/Webhook.lua
@@ -13,7 +13,7 @@ local Resolver = require('client/Resolver')
 
 local defaultAvatar = enums.defaultAvatar
 
-local Webhook, get = require('class')('Webhook', Snowflake)
+local Webhook, get, set = require('class')('Webhook', Snowflake)
 
 function Webhook:__init(data, parent)
 	Snowflake.__init(self, data, parent)
@@ -118,6 +118,10 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p type number The type of the webhook. See the `webhookType` enum for a human-readable representation.]=]
 function get.type(self)
 	return self._type
@@ -126,6 +130,10 @@ end
 --[=[@p avatar string/nil The hash for the webhook's custom avatar, if one is set.]=]
 function get.avatar(self)
 	return self._avatar
+end
+
+function set.avatar(self, value)
+	return self:setAvatar(value)
 end
 
 --[=[@p avatarURL string Equivalent to the result of calling `Webhook:getAvatarURL()`.]=]

--- a/libs/containers/abstract/Channel.lua
+++ b/libs/containers/abstract/Channel.lua
@@ -39,6 +39,8 @@ function Channel:_delete()
 			cache = self._parent._group_channels
 		elseif t == channelType.voice then
 			cache = self._parent._voice_channels
+		elseif t == channelType.stage then
+			cache = self._parent._stage_channels
 		elseif t == channelType.category then
 			cache = self._parent._categories
 		end

--- a/libs/containers/abstract/GuildChannel.lua
+++ b/libs/containers/abstract/GuildChannel.lua
@@ -78,6 +78,8 @@ local function getSortedChannels(self)
 		channels = self._parent._text_channels
 	elseif t == channelType.voice then
 		channels = self._parent._voice_channels
+	elseif t == channelType.stage then
+		channels = self._parent._stage_channels
 	elseif t == channelType.category then
 		channels = self._parent._categories
 	end

--- a/libs/containers/abstract/GuildChannel.lua
+++ b/libs/containers/abstract/GuildChannel.lua
@@ -21,7 +21,7 @@ local insert, sort = table.insert, table.sort
 local min, max, floor = math.min, math.max, math.floor
 local huge = math.huge
 
-local GuildChannel, get = class('GuildChannel', Channel)
+local GuildChannel, get, set = class('GuildChannel', Channel)
 
 function GuildChannel:__init(data, parent)
 	Channel.__init(self, data, parent)
@@ -255,6 +255,10 @@ function get.name(self)
 	return self._name
 end
 
+function set.name(self, value)
+	return self:setName(value)
+end
+
 --[=[@p position number The position of the channel, where 0 is the highest.]=]
 function get.position(self)
 	return self._position
@@ -268,6 +272,10 @@ end
 --[=[@p category GuildCategoryChannel/nil The parent channel category that may contain this channel.]=]
 function get.category(self)
 	return self._parent._categories:get(self._parent_id)
+end
+
+function set.category(self, value)
+	return self:setCategory(value)
 end
 
 --[=[@p private boolean Whether the "everyone" role has permission to view this

--- a/libs/endpoints.lua
+++ b/libs/endpoints.lua
@@ -37,6 +37,8 @@ return {
 	GUILD_REGIONS                 = "/guilds/%s/regions",
 	GUILD_ROLE                    = "/guilds/%s/roles/%s",
 	GUILD_ROLES                   = "/guilds/%s/roles",
+	GUILD_VOICE_STATE             = "/guilds/%s/voice-states/%s",
+	GUILD_VOICE_STATE_ME          = "/guilds/%s/voice-states/@me",
 	GUILD_WEBHOOKS                = "/guilds/%s/webhooks",
 	INVITE                        = "/invites/%s",
 	OAUTH2_APPLICATION_ME         = "/oauth2/applications/@me",
@@ -51,4 +53,6 @@ return {
 	WEBHOOK_TOKEN                 = "/webhooks/%s/%s",
 	WEBHOOK_TOKEN_GITHUB          = "/webhooks/%s/%s/github",
 	WEBHOOK_TOKEN_SLACK           = "/webhooks/%s/%s/slack",
+	STAGE_INSTANCE                = "/stage-instances/%s",
+	STAGE_INSTANCES               = "/stage-instances",
 }

--- a/libs/enums.lua
+++ b/libs/enums.lua
@@ -46,12 +46,17 @@ enums.notificationSetting = enum {
 }
 
 enums.channelType = enum {
-	text     = 0,
-	private  = 1,
-	voice    = 2,
-	group    = 3,
-	category = 4,
-	news     = 5,
+	text     		 = 0,
+	private 		 = 1,
+	voice   		 = 2,
+	group   		 = 3,
+	category		 = 4,
+	news    		 = 5,
+	store 			 = 6,
+	news_thread 	 = 10,
+	public_thread 	 = 11,
+	private_thread 	 = 12,
+	stage 	 		 = 13,
 }
 
 enums.webhookType = enum {
@@ -60,18 +65,28 @@ enums.webhookType = enum {
 }
 
 enums.messageType = enum {
-	default                       = 0,
-	recipientAdd                  = 1,
-	recipientRemove               = 2,
-	call                          = 3,
-	channelNameChange             = 4,
-	channelIconchange             = 5,
-	pinnedMessage                 = 6,
-	memberJoin                    = 7,
-	premiumGuildSubscription      = 8,
-	premiumGuildSubscriptionTier1 = 9,
-	premiumGuildSubscriptionTier2 = 10,
-	premiumGuildSubscriptionTier3 = 11,
+	default                                 = 0,
+	recipientAdd                            = 1,
+	recipientRemove                         = 2,
+	call                                    = 3,
+	channelNameChange                       = 4,
+	channelIconchange                       = 5,
+	pinnedMessage                           = 6,
+	memberJoin                              = 7,
+	premiumGuildSubscription                = 8,
+	premiumGuildSubscriptionTier1           = 9,
+	premiumGuildSubscriptionTier2           = 10,
+	premiumGuildSubscriptionTier3           = 11,
+	followAdd                               = 12,
+	guildDiscoveryDisqualified              = 14,
+	guildDiscoveryRequalified               = 15,
+	guildDiscoveryGracePeriodInitialWarning	= 16,
+	guildDiscoveryGracePeriodFinalWarning   = 17,
+	threadCreated                           = 18,
+	reply                                   = 19,
+	applicationCommand                      = 20,
+	threadStarterMessage                    = 21,
+	guildInviteReminder                     = 22,
 }
 
 enums.relationshipType = enum {
@@ -86,7 +101,9 @@ enums.activityType = enum {
 	default   = 0,
 	streaming = 1,
 	listening = 2,
+	watching  = 3,
 	custom    = 4,
+	competing = 5,
 }
 
 enums.status = enum {
@@ -100,7 +117,9 @@ enums.gameType = enum { -- NOTE: deprecated; use activityType
 	default   = 0,
 	streaming = 1,
 	listening = 2,
+	watching  = 3,
 	custom    = 4,
+	competing = 5,
 }
 
 enums.verificationLevel = enum {
@@ -125,36 +144,42 @@ enums.premiumTier = enum {
 }
 
 enums.permission = enum {
-	createInstantInvite = 0x00000001,
-	kickMembers         = 0x00000002,
-	banMembers          = 0x00000004,
-	administrator       = 0x00000008,
-	manageChannels      = 0x00000010,
-	manageGuild         = 0x00000020,
-	addReactions        = 0x00000040,
-	viewAuditLog        = 0x00000080,
-	prioritySpeaker     = 0x00000100,
-	stream              = 0x00000200,
-	readMessages        = 0x00000400,
-	sendMessages        = 0x00000800,
-	sendTextToSpeech    = 0x00001000,
-	manageMessages      = 0x00002000,
-	embedLinks          = 0x00004000,
-	attachFiles         = 0x00008000,
-	readMessageHistory  = 0x00010000,
-	mentionEveryone     = 0x00020000,
-	useExternalEmojis   = 0x00040000,
-	connect             = 0x00100000,
-	speak               = 0x00200000,
-	muteMembers         = 0x00400000,
-	deafenMembers       = 0x00800000,
-	moveMembers         = 0x01000000,
-	useVoiceActivity    = 0x02000000,
-	changeNickname      = 0x04000000,
-	manageNicknames     = 0x08000000,
-	manageRoles         = 0x10000000,
-	manageWebhooks      = 0x20000000,
-	manageEmojis        = 0x40000000,
+	createInstantInvite = 0x0000000001,
+	kickMembers         = 0x0000000002,
+	banMembers          = 0x0000000004,
+	administrator       = 0x0000000008,
+	manageChannels      = 0x0000000010,
+	manageGuild         = 0x0000000020,
+	addReactions        = 0x0000000040,
+	viewAuditLog        = 0x0000000080,
+	prioritySpeaker     = 0x0000000100,
+	stream              = 0x0000000200,
+	readMessages        = 0x0000000400,
+	sendMessages        = 0x0000000800,
+	sendTextToSpeech    = 0x0000001000,
+	manageMessages      = 0x0000002000,
+	embedLinks          = 0x0000004000,
+	attachFiles         = 0x0000008000,
+	readMessageHistory  = 0x0000010000,
+	mentionEveryone     = 0x0000020000,
+	useExternalEmojis   = 0x0000040000,
+	connect             = 0x0000100000,
+	speak               = 0x0000200000,
+	muteMembers         = 0x0000400000,
+	deafenMembers       = 0x0000800000,
+	moveMembers         = 0x0001000000,
+	useVoiceActivity    = 0x0002000000,
+	changeNickname      = 0x0004000000,
+	manageNicknames     = 0x0008000000,
+	manageRoles         = 0x0010000000,
+	manageWebhooks      = 0x0020000000,
+	manageEmojis        = 0x0040000000,
+	useSlashCommands    = 0x0080000000,
+	manageThreads       = 0x0400000000,
+	requestToSpeak      = 0x0100000000,
+	usePublicThreads    = 0x0800000000,
+	usePrivateThreads   = 0x1000000000,
+	useExternalStickers = 0x2000000000,
 }
 
 enums.messageFlag = enum {
@@ -163,6 +188,9 @@ enums.messageFlag = enum {
 	suppressEmbeds       = 0x00000004,
 	sourceMessageDeleted = 0x00000008,
 	urgent               = 0x00000010,
+	hasThread            = 0x00000020,
+	ephemeral            = 0x00000040,
+	loading              = 0x00000080,
 }
 
 enums.actionType = enum {
@@ -201,6 +229,9 @@ enums.actionType = enum {
 	integrationCreate      = 80,
 	integrationUpdate      = 81,
 	integrationDelete      = 82,
+	stickerCreate          = 90,
+	stickerUpdate          = 91,
+	stickerDelete          = 92,
 }
 
 enums.logLevel = enum {

--- a/libs/utils/Color.lua
+++ b/libs/utils/Color.lua
@@ -15,7 +15,7 @@ local band, bor = bit.band, bit.bor
 local bnot = bit.bnot
 local isInstance = class.isInstance
 
-local Color, get = class('Color')
+local Color, get, set = class('Color')
 
 local function check(self, other)
 	if not isInstance(self, Color) or not isInstance(other, Color) then
@@ -266,6 +266,18 @@ end
 --[=[@p b number The value that represents the color's blue-level.]=]
 function get.b(self)
 	return getByte(self._value, 0)
+end
+
+function set.r(self, value)
+	return self:setRed(value)
+end
+
+function set.g(self, value)
+	return self:setGreen(value)
+end
+
+function set.b(self, value)
+	return self:setBlue(value)
 end
 
 local function setByte(value, offset, new)

--- a/libs/voice/StageInstance.lua
+++ b/libs/voice/StageInstance.lua
@@ -1,0 +1,134 @@
+--[=[
+@c StageInstance x Snowflake
+@d Represents a live stage.
+]=]
+
+local Snowflake = require('containers/abstract/Snowflake')
+local enums = require('enums')
+local json = require('json')
+
+local StageInstance, get, set = require('class')('StageInstance', Snowflake)
+
+function StageInstance:__init(data, channel)
+	Snowflake.__init(self, data, channel)
+    return self:_loadMore(data)
+end
+
+function StageInstance:_load(data)
+    Snowflake._load(self, data)
+    return self:_loadMore(data)
+end
+
+function StageInstance:_loadMore(data)
+	if data.host_id then
+		self._host = self._parent.guild:getMember(data.host_id)
+	end
+end
+
+function StageInstance:_modify(payload)
+	local data, err = self.client._api:modifyStageInstance(self._parent._id, payload)
+	if data then
+		self:_load(data)
+		return true
+	else
+		return false, err
+	end
+end
+
+--[=[
+@m delete
+@t http
+@r boolean
+@d Permanently deletes the stage instance. This cannot be undone!
+]=]
+function StageInstance:delete()
+	local data, err = self.client._api:deleteStageInstance(self._parent._id)
+	if data then
+        self._parent._instance = nil
+		return true
+	else
+		return false, err
+	end
+end
+
+--[=[
+@m setTopic
+@t http
+@p topic string
+@r boolean
+@d Sets the instance's topic. This must be between 1 and 120 characters.
+]=]
+function StageInstance:setTopic(topic)
+	return self:_modify({topic = topic or json.null})
+end
+
+--[=[
+@m setPrivacyLevel
+@t http
+@p privacyLevel number
+@r boolean
+@d Sets the instance's privacy level. Cannot change privacy level when it is set to public.
+See the `privacyLevel` enumeration for a human-readable representation.
+]=]
+function StageInstance:setPrivacyLevel(privacyLevel)
+    if self._privacy_level == privacyLevel then
+        return false, 'The privacy level is already set to that.'
+    end
+    if self._privacy_level == enums.privacyLevel.public then
+        return false, 'Cannot change privacy level when it is set to public.'
+    end
+	return self:_modify({privacy_level = privacyLevel or json.null})
+end
+
+--[=[@p discoverableDisabled boolean Whether or not Stage Discovery is disabled.]=]
+function get.discoverableDisabled(self)
+	return self._discoverable_disabled
+end
+
+--[=[@p inviteCode string/nil The invite code. Will be nil if the privacyLevel is not public.]=]
+function get.inviteCode(self)
+	return self._invite_code
+end
+
+--[=[@p topic string The topic of the Stage instance (1-120 characters)]=]
+function get.topic(self)
+	return self._topic
+end
+
+--[=[@p privacyLevel number The privacy level. See the `privacyLevel` enumeration for a
+human-readable representation.]=]
+function get.privacyLevel(self)
+	return self._privacy_level
+end
+
+function set.topic(self, value)
+	return self:setTopic(value)
+end
+
+function set.privacyLevel(self, value)
+	return self:setPrivacyLevel(value)
+end
+
+--[=[@p guild Guild The guild of the instance's channel. Equivalent to `StageInstance.channel.guild`.]=]
+function get.guild(self)
+	return self._parent.guild
+end
+
+--[=[@p channel GuildStageChannel The corresponding GuildStageChannel for
+this instance.]=]
+function get.channel(self)
+	return self._parent
+end
+
+--[=[@p host Member/nil The member who created this stage instance, if it was cached.]=]
+function get.host(self)
+	return self._host
+end
+
+--[=[@p sendStartNotification boolean Whether it pings the whole server on start.]=]
+function get.sendStartNotification(self)
+    if self._send_start_notification == nil then return true end
+	return self._send_start_notification
+end
+
+return StageInstance

--- a/libs/voice/VoiceConnection.lua
+++ b/libs/voice/VoiceConnection.lua
@@ -423,7 +423,7 @@ function VoiceConnection:close()
 	return self._client._shards[guild.shardId]:updateVoice(guild._id)
 end
 
---[=[@p channel GuildVoiceChannel/nil The corresponding GuildVoiceChannel for
+--[=[@p channel GuildVoiceChannel/GuildStageChannel/nil The corresponding GuildVoiceChannel/GuildStageChannel for
 this connection, if one exists.]=]
 function get.channel(self)
 	return self._channel


### PR DESCRIPTION
Property setters for a few classes have been added. They are shortcuts for any `class:setSomething`.
Example: `member.nickname = "John Doe"` is a shortcut for `member:setNickname("John Doe")`

New events: `stageChannelJoin`, `stageChannelLeave`, `stageInstanceCreate`, `stageInstanceUpdate`, `stageInstanceDelete`, `messageDeleteBulk`

- New API functions
   - `API:getStageInstance`
   - `API:createStageInstance`
   - `API:modifyStageInstance`
   - `API:deleteStageInstance`

- Added `GuildStageChannel` class
   - `instance` property
   - `getInstance` function
   - `createInstance` function
   - `deleteInstance` function
   
- Added `StageInstance` class
   - `topic` property
   - `privacyLevel` property
   - `inviteCode` property
   - `discoverableDisabled` property
   - `sendStartNotification` property
   - `host` property
   - `setTopic` function
   - `setPrivacyLevel` function
   - `delete` function
   
- Members now have a `connectedChannel` property, `stageChannel` property, and `setConnectedChannel` function.
- GuildCategoryChannels now have a `stageChannels` property and `createStageChannel` function.
- Guilds now have a `createStageChannel` function.
- Added `privacyLevel` enum that is used in `StageInstance`