### PR TITLE
helpers.readOnly() to define missing metamethods

### DIFF
--- a/libs/helpers.lua
+++ b/libs/helpers.lua
@@ -99,6 +99,16 @@ local function readOnly(tbl)
 				return k, v
 			end
 		end,
+		__ipairs = function()
+			local i = 0
+			return function()
+				i = i + 1
+				if i <= #tbl then return i, tbl[i] end
+			end
+		end,
+		__len = function()
+			return #tbl
+		end
 	})
 end
 


### PR DESCRIPTION
Currently, the `readOnly` function provided by the `helpers` module only defines the `__index` and `__pairs` metamethods for read-only proxy tables, meaning that iterating via `ipairs` does not work and neither does checking the length of the read-only table. This pull request fixes that by defining the `__ipairs` and `__len` metamethods.