### PR TITLE
Update message.lua (Prevent bot from crashing when a sticker or wave is sent)

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -388,7 +388,7 @@ function get.mentionedUsers(self)
 	if not self._mentioned_users then
 		local users = self.client._users
 		local mentions = parseMentions(self._content, '<@!?(%d+)>')
-		if self._reply_target then
+		if self._reply_target and mentions then
 			insert(mentions, 1, self._reply_target)
 		end
 		self._mentioned_users = ArrayIterable(mentions, function(id)


### PR DESCRIPTION
Discord added a new feature called "wave", where a user gets to send a waving sticker when someone else joins a guild. When that wave is sent, it causes the bot to spontaneously crash because Discordia didn't know who the wave mentioned. Pretty sure that this is the solution because I tried it and it stopped my bot from crashing when the wave is sent.