### PR TITLE
Fix Date class using wrong enum

### DIFF
--- a/libs/utils/Date.lua
+++ b/libs/utils/Date.lua
@@ -263,7 +263,7 @@ end
 function Date:toMention(style)
 	local t = floor(self:toSeconds())
 	if style then
-		return format('<t:%s:%s>', t, checkEnum(enums.dateTimeStyle, style))
+		return format('<t:%s:%s>', t, checkEnum(enums.timestampStyle, style))
 	else
 		return format('<t:%s>', t)
 	end


### PR DESCRIPTION
In commit https://github.com/SinisterRectus/Discordia/commit/c9838b0a58df262e98d27c0c05d1c39cfb77c695, the `timestampStyle` enum was added. In that same commit, the method `Date:toMention()` was also added, but this method references a `dateTimeStyle` enum, which does not exist and causes Discordia to throw an error when `Date:toMention()` is called. This pull request fixes this issue by having `Date:toMention()` correcly use the `timestampStyle` enum.