### PR TITLE
Use new `embeds` field for messages and allow multiple embeds.

### DIFF
--- a/libs/containers/abstract/TextChannel.lua
+++ b/libs/containers/abstract/TextChannel.lua
@@ -261,6 +261,14 @@ function TextChannel:send(content)
 			content = concat(mentions, ' ')
 		end
 
+		local embeds
+		if tbl.embed then
+			embeds = {tbl.embed}
+		end
+		if type(tbl.embeds) == 'table' and #tbl.embeds > 0 then
+			embeds = tbl.embeds
+		end
+
 		local files
 		if tbl.file then
 			files, err = parseFile(tbl.file)
@@ -290,7 +298,7 @@ function TextChannel:send(content)
 			content = content,
 			tts = tbl.tts,
 			nonce = tbl.nonce,
-			embed = tbl.embed,
+			embeds = embeds,
 			message_reference = refMessage,
 			allowed_mentions = refMention,
 		}, files)


### PR DESCRIPTION
Use the new `embeds` field for sending messages since `embed` is now deprecated (see below), and allow sending multiple embeds in one message by specifying `embeds` in `TextChannel:send`. Specifying `embed` in the send method still works for compatibility, `embeds` will take precedence if it's a non-empty array.

( from: https://discord.com/developers/docs/change-log#june-10-2021 )
> Message routes now accept an embeds array in addition to the existing embed field. Bots can now send up to 10 embeds per message, to be consistent with webhook behavior. **The existing embed field is considered deprecated and will be removed in the next API version.**
