### PR TITLE
Utils: Add missing optional param for some utils

### DIFF
--- a/libs/utils/Permissions.lua
+++ b/libs/utils/Permissions.lua
@@ -2,6 +2,7 @@
 @c Permissions
 @t ui
 @mt mem
+@op value number
 @d Wrapper for a bitfield that is more specifically used to represent Discord
 permissions. See the `permission` enumeration for acceptable permission values.
 ]=]

--- a/libs/utils/Stopwatch.lua
+++ b/libs/utils/Stopwatch.lua
@@ -2,6 +2,7 @@
 @c Stopwatch
 @t ui
 @mt mem
+@op stopped boolean
 @d Used to measure an elapsed period of time. If a truthy value is passed as an
 argument, then the stopwatch will initialize in an idle state; otherwise, it will
 initialize in an active state. Although nanosecond precision is available, Lua

--- a/libs/utils/Time.lua
+++ b/libs/utils/Time.lua
@@ -2,6 +2,7 @@
 @c Time
 @t ui
 @mt mem
+@op value number
 @d Represents a length of time and provides utilities for converting to and from
 different formats. Supported units are: weeks, days, hours, minutes, seconds,
 and milliseconds.


### PR DESCRIPTION
Some utilities, namely: Stopwatch, Permissions and Time are missing the `@op` doc-comment.

While those utilities mostly have the acceptable values documented in theirdescription, some of the community doc-comment generated projects are missing those parameters