### PR TITLE
Message: Correct oldContent property type docs

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -516,7 +516,7 @@ function get.editedTimestamp(self)
 	return self._edited_timestamp
 end
 
---[=[@p oldContent string/table Yields a table containing keys as timestamps and
+--[=[@p oldContent table Yields a table containing keys as timestamps and
 value as content of the message at that time.]=]
 function get.oldContent(self)
 	return self._old

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -516,7 +516,7 @@ function get.editedTimestamp(self)
 	return self._edited_timestamp
 end
 
---[=[@p oldContent table Yields a table containing keys as timestamps and
+--[=[@p oldContent table/nil Yields a table containing keys as timestamps and
 value as content of the message at that time.]=]
 function get.oldContent(self)
 	return self._old


### PR DESCRIPTION
```lua
function Message:_setOldContent(d)
	local ts = d.edited_timestamp
	if not ts then return end
	local old = self._old
	if old then
		old[ts] = old[ts] or self._content
	else
		self._old = {[ts] = self._content}
	end
end
```

`self._old` is only ever changed through `_setOldContent`, and according to the code of that, `oldContent` can never be a string. Rather it is always either a table or nil (in case message was not edited, or no cache).