### PR TITLE
TextChannel: indicate getMessage can pull from cache

### DIFF
--- a/libs/containers/abstract/TextChannel.lua
+++ b/libs/containers/abstract/TextChannel.lua
@@ -26,7 +26,7 @@ end
 
 --[=[
 @m getMessage
-@t http
+@t http?
 @p id Message-ID-Resolvable
 @r Message
 @d Gets a message object by ID. If the object is already cached, then the cached


### PR DESCRIPTION
```lua
function TextChannel:getMessage(id)
	id = Resolver.messageId(id)
	local message = self._messages:get(id)
	if message then
		return message
	else
		local data, err = self.client._api:getChannelMessage(self._id, id)
		if data then
			return self._messages:_insert(data)
		else
			return nil, err
		end
	end
end
```

As we see here, getMessage checks first the messages cache, and if it has it that will be returned instead of making an HTTP request.   So the method *may* make an HTTP request, not always.