### PR TITLE
doc-comment: fix some equivalent methods optional param

### DIFF
--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -435,7 +435,7 @@ end
 --[=[
 @m kick
 @t http
-@p reason string
+@op reason string
 @r boolean
 @d Equivalent to `Member.guild:kickUser(Member.user, reason)`
 ]=]
@@ -446,8 +446,8 @@ end
 --[=[
 @m ban
 @t http
-@p reason string
-@p days number
+@op reason string
+@op days number
 @r boolean
 @d Equivalent to `Member.guild:banUser(Member.user, reason, days)`
 ]=]
@@ -458,7 +458,7 @@ end
 --[=[
 @m unban
 @t http
-@p reason string
+@op reason string
 @r boolean
 @d Equivalent to `Member.guild:unbanUser(Member.user, reason)`
 ]=]

--- a/libs/utils/Date.lua
+++ b/libs/utils/Date.lua
@@ -176,7 +176,7 @@ end
 --[=[
 @m parseTable
 @t static
-@p tbl table
+@op tbl table
 @r number
 @d Interprets a Lua date table as a local time and converts it to a Unix time in
 seconds. Equivalent to `os.time(tbl)`.
@@ -188,7 +188,7 @@ end
 --[=[
 @m parseTableUTC
 @t static
-@p tbl table
+@op tbl table
 @r number
 @d Interprets a Lua date table as a UTC time and converts it to a Unix time in
 seconds. Equivalent to `os.time(tbl)` with a correction for UTC.


### PR DESCRIPTION
I've noticed many of the methods that are documented to be an "Equivalent" of another method imply the parameters are required, when they are not.   At first I thought that was intentional, but looking at the other methods that are "equivalent" they do document that (e.x. `Reaction:delete`), therefor and to be consistant the rest of those methods should follow that trend.

It also helps with the tools that relay on the doc-comment, such as [discordia-types](https://github.com/SovietKitsune/discordia-type) and [discordia-wiki-bot](https://github.com/Bilal2453/discordia-wiki-bot).