### PR TITLE
Add support for text channels in voice chat.

### DIFF
--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -27,7 +27,7 @@ end
 local function getChannel(client, id)
 	local guild = client._channel_map[id]
 	if guild then
-		return guild._text_channels:get(id)
+		return guild._text_channels:get(id) or guild._voice_channels:get(id)
 	else
 		return client._private_channels:get(id) or client._group_channels:get(id)
 	end

--- a/libs/containers/GuildVoiceChannel.lua
+++ b/libs/containers/GuildVoiceChannel.lua
@@ -6,14 +6,14 @@ and communicate via voice chat.
 
 local json = require('json')
 
-local GuildChannel = require('containers/abstract/GuildChannel')
+local GuildTextChannel = require('containers/GuildTextChannel')
 local VoiceConnection = require('voice/VoiceConnection')
 local TableIterable = require('iterables/TableIterable')
 
-local GuildVoiceChannel, get = require('class')('GuildVoiceChannel', GuildChannel)
+local GuildVoiceChannel, get = require('class')('GuildVoiceChannel', GuildTextChannel)
 
 function GuildVoiceChannel:__init(data, parent)
-	GuildChannel.__init(self, data, parent)
+	GuildTextChannel.__init(self, data, parent)
 end
 
 --[=[


### PR DESCRIPTION
This PR adds the GuildTextChannel class a base to GuildVoiceChannel which allows you to essentially treat a voice channel as a text channel which was made possible recently by discord introducing text chat in voice channels.
It also makes the `getChannel` function found in EventHandler.lua search a guild's cache of voice channels which allows the proper receival of events for messages in these new channels. Such as MESSAGE_CREATE and MESSSAGE_UPDATE.
Should no longer receive `2022-06-11 17:56:02 | [WARNING] | Uncached TextChannel (%d) on MESSAGE_CREATE` warnings.