### PR TITLE
2.x: Logger pretty newlines

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -67,6 +67,7 @@ local defaultOptions = {
 	logLevel = logLevel.info,
 	gatewayFile = 'gateway.json',
 	dateTime = '%F %T',
+	prettyNewlines = true,
 	syncGuilds = false,
 }
 
@@ -112,7 +113,7 @@ function Client:__init(options)
 	self._private_channels = Cache({}, PrivateChannel, self)
 	self._relationships = Cache({}, Relationship, self)
 	self._webhooks = WeakCache({}, Webhook, self) -- used for audit logs
-	self._logger = Logger(options.logLevel, options.dateTime, options.logFile)
+	self._logger = Logger(options.logLevel, options.dateTime, options.logFile, options.prettyNewlines)
 	self._voice = VoiceManager(self)
 	self._role_map = {}
 	self._emoji_map = {}


### PR DESCRIPTION
2.x backport of #320.

Additionally, unlike #320, this shouldn't introduce breaking changes to the return value of `Logger:log()`.