### PR TITLE
Fix for certain events not triggering (in v8?)

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -70,7 +70,7 @@ local defaultOptions = {
 	gatewayFile = 'gateway.json',
 	dateTime = '%F %T',
 	syncGuilds = false,
-	gatewayIntents = 3243773, -- all non-privileged intents
+	gatewayIntents = 3276799, -- all non-privileged intents
 }
 
 local function parseOptions(customOptions)


### PR DESCRIPTION
Fixes e.g. GUILD_MEMBER_ADD event not triggering at all (Discord won't send it in the first place).
Intent code generated thanks to https://discord-intents-calculator.vercel.app/. It would be best to verify if that intent code is actually the good one before pulling this request, because I only tested it on one event, and it worked.

Idea for fixing this issue came from here: https://stackoverflow.com/a/65640810