### PR TITLE
Fix permissions on arm processors and prepare for permissions change

### DIFF
--- a/libs/client/Resolver.lua
+++ b/libs/client/Resolver.lua
@@ -150,7 +150,7 @@ function Resolver.permissions(obj)
 	if isInstance(obj, classes.Permissions) then
 		return obj.value
 	end
-	return tonumber(obj)
+	return int(obj)
 end
 
 function Resolver.permission(obj)
@@ -159,7 +159,11 @@ function Resolver.permission(obj)
 	if t == 'string' then
 		n = permission[obj]
 	elseif t == 'number' then
-		n = permission(obj) and obj
+		n = permission(uint64_t(obj)) and obj
+	elseif t == 'cdata' then
+		if istype(int64_t, obj) or istype(uint64_t, obj) then
+			n = permission(uint64_t(obj)) and obj
+		end
 	end
 	return n
 end
@@ -170,7 +174,11 @@ function Resolver.gatewayIntent(obj)
 	if t == 'string' then
 		n = gatewayIntent[obj]
 	elseif t == 'number' then
-		n = gatewayIntent(obj) and obj
+		n = gatewayIntent(uint64_t(obj)) and obj
+	elseif t == 'cdata' then
+		if istype(int64_t, obj) or istype(uint64_t, obj) then
+			n = gatewayIntent(uint64_t(obj)) and obj
+		end
 	end
 	return n
 end
@@ -192,7 +200,11 @@ function Resolver.messageFlag(obj)
 	if t == 'string' then
 		n = messageFlag[obj]
 	elseif t == 'number' then
-		n = messageFlag(obj) and obj
+		n = messageFlag(uint64_t(obj)) and obj
+	elseif t == 'cdata' then
+		if istype(int64_t, obj) or istype(uint64_t, obj) then
+			n = messageFlag(uint64_t(obj)) and obj
+		end
 	end
 	return n
 end

--- a/libs/client/Shard.lua
+++ b/libs/client/Shard.lua
@@ -222,7 +222,7 @@ function Shard:identify()
 		large_threshold = options.largeThreshold,
 		shard = {self._id, client._total_shard_count},
 		presence = next(client._presence) and client._presence,
-		intents = client._intents,
+		intents = tonumber(client._intents),
 	}, true)
 
 end

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -216,7 +216,7 @@ end
 ]=]
 function Message:hideEmbeds()
 	local flags = bor(self._flags or 0, messageFlag.suppressEmbeds)
-	return self:_modify({flags = flags})
+	return self:_modify({flags = tonumber(flags)})
 end
 
 --[=[
@@ -227,7 +227,7 @@ end
 ]=]
 function Message:showEmbeds()
 	local flags = band(self._flags or 0, bnot(messageFlag.suppressEmbeds))
-	return self:_modify({flags = flags})
+	return self:_modify({flags = tonumber(flags)})
 end
 
 --[=[

--- a/libs/containers/PermissionOverwrite.lua
+++ b/libs/containers/PermissionOverwrite.lua
@@ -55,6 +55,9 @@ local function getPermissions(self)
 end
 
 local function setPermissions(self, allow, deny)
+	allow = string.format('%i', allow):match('^(%d+)')
+	deny = string.format('%i', deny):match('^(%d+)')
+
 	local data, err = self.client._api:editChannelPermissions(self._parent._id, self._id, {
 		allow = allow, deny = deny, type = self._type
 	})

--- a/libs/enums.lua
+++ b/libs/enums.lua
@@ -1,6 +1,14 @@
+local ffi = require('ffi')
+local istype = ffi.istype
+local uint64_t = ffi.typeof('uint64_t')
+
 local function enum(tbl)
 	local call = {}
 	for k, v in pairs(tbl) do
+		if istype(uint64_t, v) then
+			v = tonumber(v)
+		end
+
 		if call[v] then
 			return error(string.format('enum clash for %q and %q', k, call[v]))
 		end
@@ -8,6 +16,9 @@ local function enum(tbl)
 	end
 	return setmetatable({}, {
 		__call = function(_, k)
+			if istype(uint64_t, k) then
+				k = tonumber(k)
+			end
 			if call[k] then
 				return call[k]
 			else
@@ -155,47 +166,57 @@ enums.premiumTier = enum {
 }
 
 local function flag(n)
-	return 2^n
+	return 2ULL^n
 end
 
 enums.permission = enum {
-	createInstantInvite = flag(0),
-	kickMembers         = flag(1),
-	banMembers          = flag(2),
-	administrator       = flag(3),
-	manageChannels      = flag(4),
-	manageGuild         = flag(5),
-	addReactions        = flag(6),
-	viewAuditLog        = flag(7),
-	prioritySpeaker     = flag(8),
-	stream              = flag(9),
-	readMessages        = flag(10),
-	sendMessages        = flag(11),
-	sendTextToSpeech    = flag(12),
-	manageMessages      = flag(13),
-	embedLinks          = flag(14),
-	attachFiles         = flag(15),
-	readMessageHistory  = flag(16),
-	mentionEveryone     = flag(17),
-	useExternalEmojis   = flag(18),
-	viewGuildInsights   = flag(19),
-	connect             = flag(20),
-	speak               = flag(21),
-	muteMembers         = flag(22),
-	deafenMembers       = flag(23),
-	moveMembers         = flag(24),
-	useVoiceActivity    = flag(25),
-	changeNickname      = flag(26),
-	manageNicknames     = flag(27),
-	manageRoles         = flag(28),
-	manageWebhooks      = flag(29),
-	manageEmojis        = flag(30),
-	useSlashCommands    = flag(31),
-	requestToSpeak      = flag(32),
-	manageEvents        = flag(33),
-	manageThreads       = flag(34),
-	usePublicThreads    = flag(35),
-	usePrivateThreads   = flag(36),
+	createInstantInvite  = flag(0),
+	kickMembers          = flag(1),
+	banMembers           = flag(2),
+	administrator        = flag(3),
+	manageChannels       = flag(4),
+	manageGuild          = flag(5),
+	addReactions         = flag(6),
+	viewAuditLog         = flag(7),
+	prioritySpeaker      = flag(8),
+	stream               = flag(9),
+	readMessages         = flag(10),
+	sendMessages         = flag(11),
+	sendTextToSpeech     = flag(12),
+	manageMessages       = flag(13),
+	embedLinks           = flag(14),
+	attachFiles          = flag(15),
+	readMessageHistory   = flag(16),
+	mentionEveryone      = flag(17),
+	useExternalEmojis    = flag(18),
+	viewGuildInsights    = flag(19),
+	connect              = flag(20),
+	speak                = flag(21),
+	muteMembers          = flag(22),
+	deafenMembers        = flag(23),
+	moveMembers          = flag(24),
+	useVoiceActivity     = flag(25),
+	changeNickname       = flag(26),
+	manageNicknames      = flag(27),
+	manageRoles          = flag(28),
+	manageWebhooks       = flag(29),
+	manageEmojis         = flag(30),
+	useSlashCommands     = flag(31),
+	requestToSpeak       = flag(32),
+	manageEvents         = flag(33),
+	manageThreads        = flag(34),
+	usePublicThreads     = flag(35),
+	usePrivateThreads    = flag(36),
+	useExternalStickers  = flag(37),
+	sendMessagesThreads  = flag(38),
+	useVoiceActivities   = flag(39),
+	moderateMembers      = flag(40),
+	viewCreatorAnalytics = flag(41),
+	useSoundboard        = flag(42),
+	-- unused            = flag(43),
+	-- unused            = flag(44),
+	-- unused            = flag(45),
+	sendVoiceMessages    = flag(46),
 }
 
 enums.messageFlag = enum {


### PR DESCRIPTION
Works around a bug in luajit that seems to happen when passing a
number to `bit.bor` that is larger than 2^31-1

Additionally adds a few missing enumerations so that enableAll and
disableAll work as expected.

Fixes https://github.com/SinisterRectus/Discordia/issues/384

Also forces permissions to be sent as a string, in preparation for
when they'll no longer be allowed to be sent as a number.