### PR TITLE
PermissionOverwrite: use .type instead of ._type

### DIFF
--- a/libs/containers/PermissionOverwrite.lua
+++ b/libs/containers/PermissionOverwrite.lua
@@ -43,9 +43,9 @@ This may make an HTTP request if the object is not cached.
 ]=]
 function PermissionOverwrite:getObject()
 	local guild = self._parent._parent
-	if self._type == 'role' then
+	if self.type == 'role' then
 		return guild:getRole(self._id)
-	elseif self._type == 'member' then
+	elseif self.type == 'member' then
 		return guild:getMember(self._id)
 	end
 end


### PR DESCRIPTION
Seems like an oversight. `PermissionOverwrite._type`'s type is an integer not a string, in the `PermissionOverwrite.type` getter this integer value is resolved into a string of either `member`/`role`.  For this comparison here seems like it was intended to be `.type`.