### PR TITLE
Fix error in Member:getPermissions()

### DIFF
--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -212,7 +212,7 @@ function Member:getPermissions(channel)
 			ret = ret:union(everyone:getAllowedPermissions())
 		end
 
-		local allow, deny = 0, 0
+		local allow, deny = Permissions(), Permissions()
 		for role in self.roles:iter() do
 			if role.id ~= guild.id then -- just in case
 				local overwrite = overwrites:get(role.id)


### PR DESCRIPTION
In [Member.lua on lines 220-221](https://github.com/SinisterRectus/Discordia/blob/85ea92db5c70adfa90aa0e997f1fd11b59cc0f7f/libs/containers/Member.lua#L220-L221), we index a number, leading to an error whenever `Member:getPermissions()` is called:
```lua
local allow, deny = 0, 0
for role in self.roles:iter() do
	if role.id ~= guild.id then -- just in case
		local overwrite = overwrites:get(role.id)
		if overwrite then
			deny = deny:union(overwrite:getDeniedPermissions())
			allow = allow:union(overwrite:getAllowedPermissions())
		end
	end
end
```

Looks like this was caused by https://github.com/SinisterRectus/Discordia/commit/6493e89d787199b592c6b1fbb8f562487030053f, when numbers were swapped out for objects. This PR fixes the error by replacing the values of `allow` and `deny` with blank `Permissions` objects. 