### PR TITLE
fix for deleted objects not getting updated with new data upon recreation

### DIFF
--- a/libs/iterables/Cache.lua
+++ b/libs/iterables/Cache.lua
@@ -70,7 +70,9 @@ function Cache:_insert(data)
 		old:_load(data)
 		return old
 	elseif self._deleted[k] then
-		return insert(self, k, self._deleted[k])
+		local deleted = insert(self, k, self._deleted[k])
+		deleted:_load(data)
+		return deleted
 	else
 		local obj = self._constructor(data, self._parent)
 		return insert(self, k, obj)


### PR DESCRIPTION
Is there a specific reason `Cache:_insert` doesn't apply `:_load` to deleted objects? If no, then this PR should fix that.