### PR TITLE
Date: support discord's timestamp mention format

### DIFF
--- a/libs/enums.lua
+++ b/libs/enums.lua
@@ -324,4 +324,14 @@ enums.logLevel = enum {
 	debug   = 4,
 }
 
+enums.timestampStyle = enum {
+	shortTime      = 't',
+	longTime       = 'T',
+	shortDate      = 'd',
+	longDate       = 'D',
+	shortDateTime  = 'f',
+	longDateTime   = 'F',
+	relativeTime   = 'R',
+}
+
 return enums

--- a/libs/utils/Date.lua
+++ b/libs/utils/Date.lua
@@ -198,6 +198,19 @@ function Date.parseTableUTC(tbl)
 end
 
 --[=[
+@m parseDiscordTimestamp
+@p str string
+@r number
+@r string
+@d Interprets a Discord timestamp format string `<t:seconds:style>`,
+returns Unix time in seconds and the style if one was present.
+]=]
+function Date.parseDiscordTimestamp(str)
+	local t, s = string.match(str, '<t:(%d+):?(%a?)>')
+	return tonumber(t), s
+end
+
+--[=[
 @m fromISO
 @t static
 @p str string
@@ -291,6 +304,17 @@ function Date.fromMicroseconds(us)
 end
 
 --[=[
+@m fromDiscordTimestamp
+@t static
+@p str string
+@r Date
+@d Constructs a new Date object from the Discord timestamp format `<t:seconds:style>`.
+]=]
+function Date.fromDiscordTimestamp(str)
+	return Date((Date.parseDiscordTimestamp(str)))
+end
+
+--[=[
 @m toISO
 @op sep string
 @op tz string
@@ -379,6 +403,21 @@ end
 ]=]
 function Date:toMicroseconds()
 	return self._s * US_PER_S + self._us
+end
+
+--[=[
+@m toDiscordTimestamp
+@op style string
+@r string
+@d Returns the date converted to the Discord timestamp format `<t:seconds:style>`.
+]=]
+function Date:toDiscordTimestamp(style)
+	local t = floor(self:toSeconds())
+	if style then
+		return string.format('<t:%d:%s>', t, style)
+	else
+		return string.format('<t:%d>', t)
+	end
 end
 
 --[=[


### PR DESCRIPTION
Added the follow new methods to Date class:

- `Date.parseTimestampFormat(str)`, returns `number, string`.
- `Date.fromTimestampFormat(str)`, returns `Date`.
- `Date:toTimestampFormat(style)`, accepts `enums.timestampStyle`, returns string.

Might want to choose a better name than `TimestampFormat`, but that is what [Discord calls it internally](https://discord.com/developers/docs/reference#message-formatting) it seems.
