### PR TITLE
fix: examples: enable messageContent intent

### DIFF
--- a/examples/appender.lua
+++ b/examples/appender.lua
@@ -1,6 +1,11 @@
 local discordia = require("discordia")
 local client = discordia.Client()
 
+-- enables receiving message.content so it is not empty
+-- make sure you also enable it in Developer Portal
+-- see https://github.com/SinisterRectus/Discordia/discussions/369
+client:enableIntents(discordia.enums.gatewayIntent.messageContent)
+
 local lines = {} -- blank table of messages
 
 client:on("ready", function() -- bot is ready

--- a/examples/basicCommands.lua
+++ b/examples/basicCommands.lua
@@ -3,6 +3,11 @@ local client = discordia.Client()
 
 discordia.extensions() -- load all helpful extensions
 
+-- enables receiving message.content so it is not empty
+-- make sure you also enable it in Developer Portal
+-- see https://github.com/SinisterRectus/Discordia/discussions/369
+client:enableIntents(discordia.enums.gatewayIntent.messageContent)
+
 client:on("ready", function() -- bot is ready
 	print("Logged in as " .. client.user.username)
 end)

--- a/examples/embed.lua
+++ b/examples/embed.lua
@@ -1,6 +1,10 @@
 local discordia = require("discordia")
 local client = discordia.Client()
 
+-- enables receiving message.content so it is not empty
+-- make sure you also enable it in Developer Portal
+-- see https://github.com/SinisterRectus/Discordia/discussions/369
+client:enableIntents(discordia.enums.gatewayIntent.messageContent)
 
 client:on("ready", function() -- bot is ready
 	print("Logged in as " .. client.user.username)

--- a/examples/helpCommandExample.lua
+++ b/examples/helpCommandExample.lua
@@ -2,6 +2,11 @@ local discordia = require('discordia')
 local client = discordia.Client()
 discordia.extensions() -- load all helpful extensions
 
+-- enables receiving message.content so it is not empty
+-- make sure you also enable it in Developer Portal
+-- see https://github.com/SinisterRectus/Discordia/discussions/369
+client:enableIntents(discordia.enums.gatewayIntent.messageContent)
+
 local prefix = "."
 local commands = {
 	[prefix .. "ping"] = {
@@ -33,7 +38,7 @@ client:on("messageCreate", function(message)
 	if args[1] == prefix.."help" then -- display all the commands
 		local output = {}
 		for word, tbl in pairs(commands) do
-			table.insert(output, "Command: " .. word .. "\nDescription: " .. tbl.description)
+			table.insert(output, string.format("Command: %s\nDescription: %s", word, tbl.description))
 		end
 
 		message:reply(table.concat(output, "\n\n"))

--- a/examples/pingPong.lua
+++ b/examples/pingPong.lua
@@ -1,6 +1,11 @@
 local discordia = require("discordia")
 local client = discordia.Client()
 
+-- enables receiving message.content so it is not empty
+-- make sure you also enable it in Developer Portal
+-- see https://github.com/SinisterRectus/Discordia/discussions/369
+client:enableIntents(discordia.enums.gatewayIntent.messageContent)
+
 client:on("ready", function() -- bot is ready
 	print("Logged in as " .. client.user.username)
 end)


### PR DESCRIPTION
Explicitly indicates that the user has to enable the messageContent privileged intent if they wish for the examples to work.