### PR TITLE
feat: Add crosspost and news channel supports

### DIFF
--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -280,6 +280,11 @@ function API:createMessage(channel_id, payload, files) -- TextChannel:send
 	return self:request("POST", endpoint, payload, nil, files)
 end
 
+function API:crosspostMessage(channel_id, message_id) -- Message:crosspost
+	local endpoint = f(endpoints.CHANNEL_MESSAGE_CROSSPOST, channel_id, message_id)
+	return self:request("POST", endpoint)
+end
+
 function API:createReaction(channel_id, message_id, emoji, payload) -- Message:addReaction
 	local endpoint = f(endpoints.CHANNEL_MESSAGE_REACTION_ME, channel_id, message_id, urlencode(emoji))
 	return self:request("PUT", endpoint, payload)
@@ -338,6 +343,11 @@ end
 function API:deleteChannelPermission(channel_id, overwrite_id) -- PermissionOverwrite:delete
 	local endpoint = f(endpoints.CHANNEL_PERMISSION, channel_id, overwrite_id)
 	return self:request("DELETE", endpoint)
+end
+
+function API:followNewsChannel(channel_id, payload) -- GuildChannel:follow
+	local endpoint = f(endpoints.CHANNEL_FOLLOWERS, channel_id)
+	return self:request("POST", endpoint, payload)
 end
 
 function API:triggerTypingIndicator(channel_id, payload) -- TextChannel:broadcastTyping

--- a/libs/containers/GuildTextChannel.lua
+++ b/libs/containers/GuildTextChannel.lua
@@ -118,6 +118,26 @@ function GuildTextChannel:enableNSFW()
 end
 
 --[=[
+@m follow
+@t http
+@p targetId Channel-ID-Resolvable
+@r string
+@d Follow this News channel and publish announcements to `targetId`.
+Returns a 403 HTTP error if `GuildTextChannel.isNews` is false.
+]=]
+function GuildTextChannel:follow(targetId)
+	targetId = Resolver.channelId(targetId)
+	local data, err = self.client._api:followNewsChannel(self._id, {
+		webhook_channel_id = targetId,
+	})
+	if data then
+		return data.webhook_id
+	else
+		return nil, err
+	end
+end
+
+--[=[
 @m disableNSFW
 @t http
 @r boolean

--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -393,6 +393,22 @@ function Message:reply(content)
 	return self._parent:send(content)
 end
 
+--[=[
+@m crosspost
+@t http
+@r Message
+@d Publish this announcement message to all following channels.
+Returns the current Message object, for compatibility reasons.
+]=]
+function Message:crosspost()
+	local data, err = self.client._api:crosspostMessage(self._parent._id, self._id)
+	if data then
+		return self._parent._messages:_insert(data)
+	else
+		return nil, err
+	end
+end
+
 --[=[@p reactions Cache An iterable cache of all reactions that exist for this message.]=]
 function get.reactions(self)
 	if not self._reactions then

--- a/libs/endpoints.lua
+++ b/libs/endpoints.lua
@@ -1,9 +1,11 @@
 return {
 	CHANNEL                       = "/channels/%s",
+	CHANNEL_FOLLOWERS             = "/channels/%s/followers",
 	CHANNEL_INVITES               = "/channels/%s/invites",
 	CHANNEL_MESSAGE               = "/channels/%s/messages/%s",
 	CHANNEL_MESSAGES              = "/channels/%s/messages",
 	CHANNEL_MESSAGES_BULK_DELETE  = "/channels/%s/messages/bulk-delete",
+	CHANNEL_MESSAGE_CROSSPOST     = "/channels/%s/messages/%s/crosspost",
 	CHANNEL_MESSAGE_REACTION      = "/channels/%s/messages/%s/reactions/%s",
 	CHANNEL_MESSAGE_REACTIONS     = "/channels/%s/messages/%s/reactions",
 	CHANNEL_MESSAGE_REACTION_ME   = "/channels/%s/messages/%s/reactions/%s/@me",


### PR DESCRIPTION
Adds the ability to follow Announcement/News channels, as well as the ability to crosspost messages.
This should be forward compatible with the dev branch.

### New Methods

- `Message:crosspost()` - cross-posts the message publishing it into following channels

- `GuildTextChannel:follow(targetId)` - start following the news channel and publishing announcements into `targetId`.

Note: to access the original message of a cross-posted message `referencedMessage` can be used. Currently the docs for it are wrong, `referencedMessage` is more than just replies.