### PR TITLE
chore: Sticker: fix docs and general cleanup

### DIFF
--- a/libs/containers/Message.lua
+++ b/libs/containers/Message.lua
@@ -463,7 +463,7 @@ function get.mentionedChannels(self)
 	return self._mentioned_channels
 end
 
---[=[@p Sticker ArrayIterable An iterable array of all stickers that are sent in this message.]=]
+--[=[@p stickers ArrayIterable An iterable array of all stickers that are sent in this message.]=]
 function get.stickers(self)
 	if not self._stickers then
 		local client = self.client
@@ -479,7 +479,7 @@ function get.stickers(self)
 	return self._stickers
 end
 
---[=[@p Sticker The first sticker that is sent in this message.]=]
+--[=[@p sticker Sticker The first sticker that is sent in this message.]=]
 function get.sticker(self)
 	return self.stickers and self.stickers.first or nil
 end

--- a/libs/containers/Sticker.lua
+++ b/libs/containers/Sticker.lua
@@ -13,16 +13,10 @@ local Sticker, get = require('class')('Sticker', Snowflake)
 function Sticker:__init(data, parent)
 	Snowflake.__init(self, data, parent)
 	self.client._sticker_map[self._id] = parent
-	return self:_loadMore(data)
 end
 
 function Sticker:_load(data)
 	Snowflake._load(self, data)
-	return self:_loadMore(data)
-end
-
-function Sticker:_loadMore(data)
-	
 end
 
 function Sticker:_modify(payload)
@@ -77,10 +71,7 @@ end
 function Sticker:delete()
 	local data, err = self.client._api:deleteGuildSticker(self._parent._id, self._id)
 	if data then
-		local cache = self._parent._stickers
-		if cache then
-			cache:_delete(self._id)
-		end
+		self._parent._stickers:_delete(self._id)
 		return true
 	else
 		return false, err
@@ -102,6 +93,7 @@ function get.tags(self)
 	return self._tags
 end
 
+--[=[@p type number The sticker format type.]=]
 function get.type(self)
 	return self._format_type
 end


### PR DESCRIPTION
Just a bit of documentation fix.

I noticed this
```lua
--[=[@p stickers ArrayIterable An iterable array of all stickers that are sent in this message.]=]
function get.stickers(self)
	if not self._stickers then
		local client = self.client
		self._stickers = ArrayIterable(self._sticker_items, function(sticker)
			if sticker.format_type == 1 then
				local guild = client._sticker_map[sticker.id]
				return guild and guild._stickers:get(sticker.id) or nil
			else
				-- return client:getSticker(sticker.id) ??
			end
		end)
	end
	return self._stickers
end
```
There should be no reason to only load stickers of type `1`, but I will look into it properly later.