### PR TITLE
fix: class: return false instead of nil

### DIFF
--- a/libs/class.lua
+++ b/libs/class.lua
@@ -27,11 +27,11 @@ function default:__hash()
 end
 
 local function isClass(cls)
-	return classes[cls]
+	return not not classes[cls]
 end
 
 local function isObject(obj)
-	return objects[obj]
+	return not not objects[obj]
 end
 
 local function isSubclass(sub, cls)


### PR DESCRIPTION
According to the [documentation](https://github.com/SinisterRectus/Discordia/wiki/Classes#isclass) `isClass` and `isObject` explicitly returns false when unmatched, in reality `nil` is returned since it is just a simple table lookup.

I don't know if you want to change the docs or change the behavior, but this PR does the latter.
