### PR TITLE
docs: change Intesnts-Resolvables to Gateway-Intent-Resolvable

### DIFF
--- a/libs/client/Client.lua
+++ b/libs/client/Client.lua
@@ -329,7 +329,7 @@ end
 --[=[
 @m setIntents
 @t mem
-@p intents Intents-Resolvable
+@p intents Gateway-Intent-Resolvable
 @r nothing
 @d Sets the gateway intents that this client will use. The new value will not be
 used internally until the client (re-)identifies.
@@ -341,7 +341,7 @@ end
 --[=[
 @m enableIntents
 @t mem
-@p ... Intents-Resolvables
+@p ... Gateway-Intent-Resolvables
 @r nothing
 @d Enables individual gateway intents for this client. The new value will not be
 used internally until the client (re-)identifies.
@@ -356,7 +356,7 @@ end
 --[=[
 @m disableIntents
 @t mem
-@p ... Intents-Resolvables
+@p ... Gateway-Intent-Resolvables
 @r nothing
 @d Disables individual gateway intents for this client. The new value will not be
 used internally until the client (re-)identifies.


### PR DESCRIPTION
I don't know if this is a change that makes sense for you, so feel free to close it if not. But here is the analogy behind it: from what I can see resolvables use singular nouns for when they represent *one* thing of the type, for example `Permission-Resolvable` vs `Permissions-Resolvable`, in this case, the resolvable represents a single value only (many of those singular values are accepted as varargs though), so the singular noun should be used instead.

I am also adding `gateway` to make it clear that this also corresponds with the `gatewayIntent` enumeration.

