### PR TITLE
switching from the creationix packages to luvit

### DIFF
--- a/package.lua
+++ b/package.lua
@@ -25,9 +25,9 @@ return {
 	version = '2.12.0',
 	homepage = 'https://github.com/SinisterRectus/Discordia',
 	dependencies = {
-		'creationix/coro-http@3.1.0',
-		'creationix/coro-websocket@3.1.0',
-		'luvit/secure-socket@1.2.2',
+		'luvit/coro-http@3.2.3',
+		'luvit/coro-websocket@3.1.1',
+		'luvit/secure-socket@1.2.4',
 	},
 	tags = {'discord', 'api'},
 	license = 'MIT',


### PR DESCRIPTION
In the lights of https://github.com/luvit/lit/pull/331, moving dependencies to the `luvit/` ones, as it contains an important `coro-websocket` fix affecting voice https://github.com/luvit/lit/commit/8313638b279fdb4d6efd5e8c94544456b5077d71.

The version number changes should not matter as lit always pulls latest major version available.
