### PR TITLE
Added event handle for Guild Join Requests

### DIFF
--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -320,6 +320,25 @@ function EventHandler.GUILD_ROLE_DELETE(d, client) -- role object not provided
 	return client:emit('roleDelete', role)
 end
 
+function EventHandler.GUILD_JOIN_REQUEST_UPDATE(d, client)
+	local status = d.status
+	local user = client:getUser(d.request.user_id)
+	local form_responses = d.request.form_responses
+	if status == "SUBMITTED" then
+		return client:emit('memberApplicationSubmitted', user, form_responses)
+	elseif  status == "APPROVED" then
+		return client:emit('memberApplicationApproved', user, form_responses)
+	elseif  status == "REJECTED" then
+		local rejection_reason = d.request.rejection_reason
+		return client:emit('memberApplicationRejected', user, form_responses, rejection_reason)
+	end
+end
+
+function EventHandler.GUILD_JOIN_REQUEST_DELETE(d, client)
+	local user = client:getUser(d.user_id)
+	return client:emit('memberApplicationDelete', user)
+end
+
 function EventHandler.MESSAGE_CREATE(d, client)
 	local channel = getChannel(client, d)
 	if not channel then return warning(client, 'TextChannel', d.channel_id, 'MESSAGE_CREATE') end

--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -325,18 +325,18 @@ function EventHandler.GUILD_JOIN_REQUEST_UPDATE(d, client)
 	local user = client:getUser(d.request.user_id)
 	local form_responses = d.request.form_responses
 	if status == "SUBMITTED" then
-		return client:emit('memberApplicationSubmitted', user, form_responses)
+		return client:emit('guildJoinRequestSubmitted', user, form_responses)
 	elseif  status == "APPROVED" then
-		return client:emit('memberApplicationApproved', user, form_responses)
+		return client:emit('guildJoinRequestApproved', user, form_responses)
 	elseif  status == "REJECTED" then
 		local rejection_reason = d.request.rejection_reason
-		return client:emit('memberApplicationRejected', user, form_responses, rejection_reason)
+		return client:emit('guildJoinRequestRejected', user, form_responses, rejection_reason)
 	end
 end
 
 function EventHandler.GUILD_JOIN_REQUEST_DELETE(d, client)
 	local user = client:getUser(d.user_id)
-	return client:emit('memberApplicationDelete', user)
+	return client:emit('guildJoinRequestDelete', user)
 end
 
 function EventHandler.MESSAGE_CREATE(d, client)

--- a/libs/client/Shard.lua
+++ b/libs/client/Shard.lua
@@ -47,8 +47,6 @@ local ignore = {
 	['INTEGRATION_DELETE'] = true,
 	['EMBEDDED_ACTIVITY_UPDATE'] = true,
 	['GIFT_CODE_UPDATE'] = true,
-	['GUILD_JOIN_REQUEST_UPDATE'] = true,
-	['GUILD_JOIN_REQUEST_DELETE'] = true,
 	['APPLICATION_COMMAND_PERMISSIONS_UPDATE'] = true,
 }
 


### PR DESCRIPTION
Added event handlers for GUILD_JOIN_REQUEST_UPDATE and GUILD_JOIN_REQUEST_DELETE in EventHandler.lua

new client:on() Events and its returns:
guildJoinRequestSubmitted-> (user, form_responses) 
guildJoinRequestDelete -> (user)
guildJoinRequestApproved -> (user, form_responses) 
guildJoinRequestRejected -> (user, form_responses, rejection_reason)

