### PR TITLE
trust that discord advertises the correct voice server port

### DIFF
--- a/libs/voice/VoiceManager.lua
+++ b/libs/voice/VoiceManager.lua
@@ -25,7 +25,7 @@ function VoiceManager:_prepareConnection(state, connection)
 		return self._client:error('Cannot prepare voice connection: libsodium not found')
 	end
 	local socket = VoiceSocket(state, connection, self)
-	local url = 'wss://' .. state.endpoint:gsub(':%d*$', '')
+	local url = 'wss://' .. state.endpoint
 	local path = format('/?v=%i', GATEWAY_VERSION_VOICE)
 	return wrap(socket.connect)(socket, url, path)
 end


### PR DESCRIPTION
This code used to exist because discord would advertise the wrong port for the voice gateway despite listening on port 443.

However it would appear recently that discord started using non-443 ports for the voice gateway causing invalid sessions or connection timeouts.