### PR TITLE
feat: add support for per-server profiles

### DIFF
--- a/libs/client/API.lua
+++ b/libs/client/API.lua
@@ -485,9 +485,9 @@ function API:modifyGuildMember(guild_id, user_id, payload) -- various Member met
 	return self:request("PATCH", endpoint, payload)
 end
 
-function API:modifyCurrentUsersNick(guild_id, payload) -- Member:setNickname
-	local endpoint = f(endpoints.GUILD_MEMBER_ME_NICK, guild_id)
-	return self:request("PATCH", endpoint, payload)
+function API:modifyCurrentMember(guild_id, payload) -- Member:setNickname, Guild:setProfile
+    local endpoint = f(endpoints.GUILD_MEMBER_ME, guild_id)
+    return self:request("PATCH", endpoint, payload)
 end
 
 function API:addGuildMemberRole(guild_id, user_id, role_id, payload) -- Member:addrole

--- a/libs/containers/Guild.lua
+++ b/libs/containers/Guild.lua
@@ -727,6 +727,28 @@ function Guild:unbanUser(id, reason)
 	end
 end
 
+--[=[
+@m setProfile
+@t http
+@p payload table
+@r boolean
+@d Sets the current client's member profile within the guild. Optional payload fields are: nick: string, bio: string, banner: file/base64, avatar: file/base64
+]=]
+function Guild:setProfile(payload)
+	payload = payload or {}
+	payload.nick = payload.nick or ""
+	payload.bio = payload.bio or ""
+	payload.avatar = payload.avatar and Resolver.base64(payload.avatar) or json.null
+	payload.banner = payload.banner and Resolver.base64(payload.banner) or json.null
+
+	local data, err = self.client._api:modifyCurrentMember(self._id, payload)
+	if data then
+		return true
+	else
+		return false, err
+	end
+end
+
 --[=[@p shardId number The ID of the shard on which this guild is served. If only one shard is in
 operation, then this will always be 0.]=]
 function get.shardId(self)

--- a/libs/containers/Member.lua
+++ b/libs/containers/Member.lua
@@ -331,7 +331,7 @@ function Member:setNickname(nick)
 	nick = nick or ''
 	local data, err
 	if self.id == self.client._user._id then
-		data, err = self.client._api:modifyCurrentUsersNick(self._parent._id, {nick = nick})
+		data, err = self.client._api:modifyCurrentMember(self._parent._id, {nick = nick})
 	else
 		data, err = self.client._api:modifyGuildMember(self._parent._id, self.id, {nick = nick})
 	end

--- a/libs/endpoints.lua
+++ b/libs/endpoints.lua
@@ -35,7 +35,7 @@ return {
 	GUILD_INVITES                 = "/guilds/%s/invites",
 	GUILD_MEMBER                  = "/guilds/%s/members/%s",
 	GUILD_MEMBERS                 = "/guilds/%s/members",
-	GUILD_MEMBER_ME_NICK          = "/guilds/%s/members/@me/nick",
+	GUILD_MEMBER_ME         	  = "/guilds/%s/members/@me",
 	GUILD_MEMBER_ROLE             = "/guilds/%s/members/%s/roles/%s",
 	GUILD_PRUNE                   = "/guilds/%s/prune",
 	GUILD_REGIONS                 = "/guilds/%s/regions",


### PR DESCRIPTION
This pull requests adds support for per-server bot profiles using new methods and endpoints.

Documentation Reference: [discord/discord-api-docs#7807](https://github.com/discord/discord-api-docs/pull/7807)

Changes:
- Added GUILD_MEMBER_ME endpoint (`/guilds/%s/members/@me`)
- Added API method `API:modifyCurrentMember(guild_id, payload)`
- Added Guild method `Guild:setProfile(payload)`
- Updated Member method `Member:setNickname(nick)` to use GUILD_MEMBER_ME endpoint instead of GUILD_MEMBER_ME_NICK which is now deprecated
- Removed API method `API:modifyCurrentUsersNick(guild_id, nick)`

Notes:
- At the time of this pull request, banners and bios are not yet visible due to a Discord client issue that should be fixed soon. (issue [#7833](https://github.com/discord/discord-api-docs/issues/7833))