### PR TITLE
fix(gateway): use resume_gateway_url when reconnecting

### DIFF
--- a/libs/client/EventHandler.lua
+++ b/libs/client/EventHandler.lua
@@ -52,6 +52,7 @@ function EventHandler.READY(d, client, shard)
 	shard:emit('READY')
 
 	shard._session_id = d.session_id
+	shard._resume_gateway_url = d.resume_gateway_url
 	client._user = client._users:_insert(d.user)
 
 	local guilds = client._guilds

--- a/libs/client/Shard.lua
+++ b/libs/client/Shard.lua
@@ -85,6 +85,7 @@ local function decrementReconnectTime(self)
 end
 
 function Shard:handleDisconnect(url, path)
+	url = self._resume_gateway_url or url
 	self._client:emit('shardDisconnect', self._id)
 	if self._reconnect then
 		self:info('Reconnecting...')


### PR DESCRIPTION
This pull requests implements the missing handling of `resume_gateway_url`, which was added to the Gateway in August of 2022 (https://docs.discord.com/developers/change-log#session-specific-gateway-resume-urls). The system was pushed into full use later in September of the same year.

This system does not exist for the Voice Gateway at the moment, hence why no changes were made there.

Changes:
- Store `Shard._resume_gateway_url` when receiving it via the `READY` event
- Use `Shard._resume_gateway_url` to reconnect if available, otherwise use original gateway URL

Documentation Reference: https://docs.discord.com/developers/events/gateway#preparing-to-resume